### PR TITLE
fix: BEAR ref_ranges offset 패턴 매처 → 완료 박스 수 기준으로 변경

### DIFF
--- a/pairUSDT/lib/predictor/predict.py
+++ b/pairUSDT/lib/predictor/predict.py
@@ -390,9 +390,10 @@ def _predict_one_coin_phase2(conn: sqlite3.Connection, bundle: dict):
         )
         _ref_bear_list = _bear_2021.to_dict("records")
         _bear_offset, _match_score = match_bear_pattern(_cur_bear_done, _ref_bear_list)
-        _ref_ranges_offset = _ref_ranges[_bear_offset:] or None
-        _ref_declines_offset = _ref_declines[_bear_offset:] or None
-        log.info("  [%s] BEAR offset=%d (유사도=%.3f) ranges=%s declines=%s", _sym, _bear_offset, _match_score, _ref_ranges_offset, _ref_declines_offset)
+        _simple_offset = len(_cur_bear_done)
+        _ref_ranges_offset = _ref_ranges[_simple_offset:] or None
+        _ref_declines_offset = _ref_declines[_simple_offset:] or None
+        log.info("  [%s] BEAR simple_offset=%d (패턴오프셋=%d 무시) ranges=%s declines=%s", _sym, _simple_offset, _bear_offset, _ref_ranges_offset, _ref_declines_offset)
 
         # 이전 사이클(2021) BULL 박스 데이터 추출
         _bull_2021 = (


### PR DESCRIPTION
## Summary
- `match_bear_pattern` 반환 offset 대신 `len(_cur_bear_done)` (완료 BEAR 박스 수) 기반 simple_offset 사용
- 패턴 매처가 마지막 박스 1개만 비교하여 실제 위치보다 offset이 밀리는 문제 수정 (예: simple=2 vs pattern=4)
- 패턴 매처 결과는 로그 비교용으로만 유지

## Test plan
- [ ] `python 032_train_and_predict_box.py` 실행 후 BTC BEAR 로그에서 `simple_offset=2 (패턴오프셋=4 무시)` 확인
- [ ] `ref_bear_ranges` 슬라이스가 `ref[2:]` 기준으로 출력되는지 확인
- [ ] 예측 박스 range_pct 값이 2021 ref[2] 이후 데이터로 반영되는지 확인

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)