### PR TITLE
feat: 032 BTC 단독 학습 제한 해제 (전체 코인 학습으로 전환)

### DIFF
--- a/pairUSDT/032_train_and_predict_box.py
+++ b/pairUSDT/032_train_and_predict_box.py
@@ -45,8 +45,8 @@ def main():
     log.info("      총 %d개 박스 (is_prediction=0)", len(df_all))
     
     # 임시: BTC만 사용 (원복 시 아래 두 줄 제거)
-    df_all = df_all[df_all["symbol"].str.upper() == "BTC"].copy()
-    log.info("      (임시) BTC만 사용 — %d개 박스", len(df_all))
+    # df_all = df_all[df_all["symbol"].str.upper() == "BTC"].copy()
+    # log.info("      (임시) BTC만 사용 — %d개 박스", len(df_all))
 
     log.info("[2/7] 연속 박스 쌍 구성")
     train_df = build_training_pairs(df_all)


### PR DESCRIPTION
## Summary
- BTC 단독 필터(`df_all = df_all[symbol == "BTC"]`) 주석 처리
- 수집 대상 확대(#15)와 함께 전체 코인 학습/예측 가능

## Test plan
- [ ] `python 032_train_and_predict_box.py` 실행 후 전체 코인 예측 확인
- [ ] BTC 외 코인 예측 결과 DB 저장 확인

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)