### PR TITLE
feat: React 프론트엔드 초기 구조 (Vite + TypeScript)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+# FastAPI 백엔드 URL (배포 시 Render URL로 변경)
+VITE_API_URL=http://localhost:8000
+
+# Supabase Realtime (선택)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cryptochart-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "@supabase/supabase-js": "^2.43.0",
+    "lightweight-charts": "^4.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.3.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CryptoChart</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import { CoinSelector } from './components/CoinSelector'
+import { CryptoChart } from './components/CryptoChart'
+import { useChartData } from './hooks/useChartData'
+
+export default function App() {
+  const [coinId, setCoinId] = useState<string | null>(null)
+  const { ohlcv, boxes, predictions, loading, error } = useChartData(coinId)
+
+  return (
+    <div style={{ background: '#0f0f0f', minHeight: '100vh', color: '#fff', padding: 24 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 24 }}>
+        <h2 style={{ margin: 0 }}>CryptoChart</h2>
+        <CoinSelector selected={coinId} onChange={setCoinId} />
+      </div>
+
+      {loading && <p>로딩 중...</p>}
+      {error   && <p style={{ color: '#f66' }}>{error}</p>}
+
+      {coinId && !loading && (
+        <CryptoChart ohlcv={ohlcv} boxes={boxes} predictions={predictions} />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,19 @@
+const BASE_URL = import.meta.env.VITE_API_URL ?? ''
+
+export async function fetchCoins() {
+  const res = await fetch(`${BASE_URL}/api/coins`)
+  if (!res.ok) throw new Error('Failed to fetch coins')
+  return res.json()
+}
+
+export async function fetchChartData(coinId: string) {
+  const res = await fetch(`${BASE_URL}/api/chart-data/${coinId}`)
+  if (!res.ok) throw new Error('Failed to fetch chart data')
+  return res.json()
+}
+
+export async function fetchPredictions(coinId: string) {
+  const res = await fetch(`${BASE_URL}/api/predictions/${coinId}`)
+  if (!res.ok) throw new Error('Failed to fetch predictions')
+  return res.json()
+}

--- a/frontend/src/components/CoinSelector.tsx
+++ b/frontend/src/components/CoinSelector.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { fetchCoins } from '../api/client'
+
+interface Props {
+  selected: string | null
+  onChange: (coinId: string) => void
+}
+
+export function CoinSelector({ selected, onChange }: Props) {
+  const [coins, setCoins] = useState<any[]>([])
+
+  useEffect(() => {
+    fetchCoins().then(setCoins).catch(console.error)
+  }, [])
+
+  return (
+    <select
+      value={selected ?? ''}
+      onChange={e => onChange(e.target.value)}
+      style={{ padding: '6px 12px', fontSize: 14 }}
+    >
+      <option value="" disabled>코인 선택</option>
+      {coins.map(c => (
+        <option key={c.id} value={c.id}>
+          #{c.rank} {c.symbol}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/frontend/src/components/CryptoChart.tsx
+++ b/frontend/src/components/CryptoChart.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react'
+import { createChart, IChartApi } from 'lightweight-charts'
+
+interface Props {
+  ohlcv: any[]
+  boxes: any[]
+  predictions: any
+}
+
+export function CryptoChart({ ohlcv, boxes, predictions }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const chartRef     = useRef<IChartApi | null>(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    chartRef.current = createChart(containerRef.current, {
+      width: containerRef.current.clientWidth,
+      height: 500,
+      layout: { background: { color: '#0f0f0f' }, textColor: '#ccc' },
+      grid: { vertLines: { color: '#222' }, horzLines: { color: '#222' } },
+    })
+    return () => { chartRef.current?.remove() }
+  }, [])
+
+  useEffect(() => {
+    if (!chartRef.current || !ohlcv.length) return
+    const series = chartRef.current.addCandlestickSeries()
+    series.setData(
+      ohlcv.map(d => ({
+        time: d.date,
+        open: d.open, high: d.high, low: d.low, close: d.close,
+      }))
+    )
+  }, [ohlcv])
+
+  return <div ref={containerRef} style={{ width: '100%' }} />
+}

--- a/frontend/src/hooks/useChartData.ts
+++ b/frontend/src/hooks/useChartData.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+import { fetchChartData, fetchPredictions } from '../api/client'
+
+export function useChartData(coinId: string | null) {
+  const [ohlcv, setOhlcv]           = useState<any[]>([])
+  const [boxes, setBoxes]           = useState<any[]>([])
+  const [predictions, setPredictions] = useState<any>(null)
+  const [loading, setLoading]       = useState(false)
+  const [error, setError]           = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!coinId) return
+    setLoading(true)
+    setError(null)
+
+    Promise.all([fetchChartData(coinId), fetchPredictions(coinId).catch(() => null)])
+      .then(([chart, preds]) => {
+        setOhlcv(chart.ohlcv)
+        setBoxes(chart.boxes)
+        setPredictions(preds)
+      })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [coinId])
+
+  return { ohlcv, boxes, predictions, loading, error }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Vite + React + TypeScript 프로젝트 구성
- `lightweight-charts` 캔들스틱 차트
- FastAPI `/api/*` 연동 (coins, chart-data, predictions)

## 구조
```
frontend/
├── package.json
├── vite.config.ts       # /api 프록시 → localhost:8000
├── src/
│   ├── App.tsx
│   ├── main.tsx
│   ├── api/client.ts     # fetchCoins / fetchChartData / fetchPredictions
│   ├── hooks/useChartData.ts
│   └── components/
│       ├── CoinSelector.tsx
│       └── CryptoChart.tsx
└── public/index.html
```

## 로컬 실행
```bash
cd frontend
npm install
npm run dev
```

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)