### PR TITLE
fix(pairUSDT): Binance BINANCE_HOSTS 단일 정의 및 REST 체인 동기화

### DIFF
--- a/01_pairUSDT/lib/common/binance_public.py
+++ b/01_pairUSDT/lib/common/binance_public.py
@@ -1,7 +1,8 @@
 """
-Binance spot 공개 API: 호스트 순차 시도.
-1순위는 config 의 BINANCE_REST_BASE_CHAIN[0] (기본 https://data.binance.com).
-data.binance.com 은 /api/v3 가 없어 404 → data-api.binance.vision 등으로 자동 폴백.
+Binance spot 공개 API: 호스트 순차 시도 및 프로세스 단위 캐시.
+
+BINANCE_HOSTS 를 순서대로 시도하고, 첫 200 응답 호스트를 _working_host 에 캐시해
+이후 kline 페이지 요청에 재사용한다.
 """
 
 from __future__ import annotations
@@ -11,11 +12,31 @@ import time
 
 import requests
 
-from lib.common.config import BINANCE_DELAY, BINANCE_REST_BASE_CHAIN
+from lib.common.config import BINANCE_DELAY, BINANCE_HOSTS, BINANCE_REST_BASE_CHAIN
 
 log = logging.getLogger(__name__)
 
 _MAX_RETRIES = 3
+
+_working_host: str | None = None
+
+
+def _get_working_host(symbol: str, quote: str) -> str | None:
+    global _working_host
+    if _working_host:
+        return _working_host
+    test_params = {"symbol": symbol + quote, "interval": "1d", "limit": 1}
+    for host in BINANCE_REST_BASE_CHAIN:
+        try:
+            r = requests.get(
+                f"{host.rstrip('/')}/api/v3/klines", params=test_params, timeout=10
+            )
+            if r.status_code == 200:
+                _working_host = host.rstrip("/")
+                return _working_host
+        except Exception:
+            continue
+    return None
 
 
 def _get_json(url: str, params: dict | None) -> dict | list | None:
@@ -51,29 +72,54 @@ def spot_get_first_working(
 ) -> tuple[dict | list | None, str | None]:
     """path 예: /api/v3/klines — 첫 성공 호스트와 JSON 반환."""
     for base in BINANCE_REST_BASE_CHAIN:
-        url = f"{base}{path}"
+        b = base.rstrip("/")
+        url = f"{b}{path}"
         data = _get_json(url, params)
         if data is not None:
-            if base != BINANCE_REST_BASE_CHAIN[0]:
-                log.info("Binance API 사용 호스트: %s", base)
-            return data, base
+            if b != BINANCE_HOSTS[0].rstrip("/"):
+                log.info("Binance API 사용 호스트: %s", b)
+            return data, b
     return None, None
 
 
 def spot_get_same_base(
     base: str, path: str, params: dict | None = None
 ) -> dict | list | None:
-    return _get_json(f"{base}{path}", params)
+    return _get_json(f"{base.rstrip('/')}{path}", params)
+
+
+def _fetch_klines_page(host: str, params: dict) -> list | None:
+    """단일 kline 페이지. 비정상 응답·예외 시 None (예외 전파 없음)."""
+    url = f"{host.rstrip('/')}/api/v3/klines"
+    for attempt in range(1, _MAX_RETRIES + 1):
+        try:
+            r = requests.get(url, params=params, timeout=30)
+            if r.status_code == 200:
+                data = r.json()
+                return data if isinstance(data, list) else None
+            if r.status_code == 429:
+                time.sleep(60 * attempt)
+                continue
+        except Exception:
+            if attempt == _MAX_RETRIES:
+                return None
+            time.sleep(5 * attempt)
+    return None
 
 
 def fetch_klines_paginated(
     symbol: str, quote: str, start_ms: int = 0, delay: float | None = None
 ) -> list[list]:
-    """일봉 kline 전부. 첫 페이지에서 성공한 호스트로 이후 페이지만 요청."""
-    path = "/api/v3/klines"
+    """
+    일봉 kline 전부. _get_working_host 로 확정한 호스트로 모든 페이지 요청.
+    모든 호스트 실패 시 [].
+    """
     sym = f"{symbol}{quote}"
     wait = BINANCE_DELAY if delay is None else delay
-    base: str | None = None
+    host = _get_working_host(symbol, quote)
+    if not host:
+        return []
+
     start_time = start_ms
     all_klines: list[list] = []
 
@@ -84,13 +130,7 @@ def fetch_klines_paginated(
             "startTime": start_time,
             "limit": 1000,
         }
-        if base:
-            data = spot_get_same_base(base, path, params)
-        else:
-            data, base = spot_get_first_working(path, params)
-            if not base:
-                return []
-
+        data = _fetch_klines_page(host, params)
         time.sleep(wait)
 
         if not data:

--- a/01_pairUSDT/lib/common/config.py
+++ b/01_pairUSDT/lib/common/config.py
@@ -15,21 +15,25 @@ load_dotenv(_WORKSPACE_ROOT / "02_backend" / ".env", override=False)
 SUPABASE_URL = os.getenv("SUPABASE_URL", "")
 SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY", "") or os.getenv("SUPABASE_KEY", "")
 
-# Binance spot 공개 REST: 1순위 .env BINANCE_API_BASE (기본 data.binance.com).
-# data.binance.com 은 /api/v3 미제공(404) → 코드에서 vision·api 순으로 자동 폴백.
-_BINANCE_PRIMARY = (os.getenv("BINANCE_API_BASE") or "https://data.binance.com").rstrip("/")
-_BINANCE_EXTRA_FALLBACKS = [
+# Binance 공개 REST 호스트 순서 (lib/common/binance_public.py 와 동일 유지)
+BINANCE_HOSTS: list[str] = [
+    "https://data.binance.com",
     "https://data-api.binance.vision",
-    "https://api.binance.com",
-    "https://api.binance.us",
+    "https://api1.binance.com",
+    "https://api2.binance.com",
+    "https://api3.binance.com",
 ]
 
 
 def _binance_rest_base_chain() -> list[str]:
+    """BINANCE_API_BASE 가 있으면 맨 앞에 넣고, 이어서 BINANCE_HOSTS (중복 제거)."""
     chain: list[str] = []
-    for b in [_BINANCE_PRIMARY] + _BINANCE_EXTRA_FALLBACKS:
+    primary = (os.getenv("BINANCE_API_BASE") or "").strip().rstrip("/")
+    if primary:
+        chain.append(primary)
+    for b in BINANCE_HOSTS:
         b = b.rstrip("/")
-        if b and b not in chain:
+        if b not in chain:
             chain.append(b)
     return chain
 


### PR DESCRIPTION
Closes #41

- \config.py\: \BINANCE_HOSTS\ 5개 고정 순서, \BINANCE_REST_BASE_CHAIN\에서 \BINANCE_API_BASE\ 선택 선두 처리
- \inance_public.py\: config에서 호스트 import, \BINANCE_REST_BASE_CHAIN\으로 프로브/페이지네이션

Made with [Cursor](https://cursor.com)