### PR TITLE
chore(frontend): Vercel 배포 환경 설정 및 API URL 정리

### DIFF
--- a/03_frontend/src/LegacyAnalyzerApp.tsx
+++ b/03_frontend/src/LegacyAnalyzerApp.tsx
@@ -9,12 +9,10 @@ function buildShell(html: string, data: unknown) {
 
 async function loadDashboardData() {
   const apiRes = await fetch(`${BASE_URL}/api/dashboard-data`)
-  if (apiRes.ok) return apiRes.json()
-
-  const sampleRes = await fetch('/legacy/sample-dashboard-data.json')
-  if (sampleRes.ok) return sampleRes.json()
-
-  throw new Error('Failed to load dashboard data (api + sample)')
+  if (!apiRes.ok) {
+    throw new Error(`Failed to load dashboard data: ${apiRes.status} ${apiRes.statusText}`)
+  }
+  return apiRes.json()
 }
 
 export default function LegacyAnalyzerApp() {

--- a/04_frontend_0222fb/src/lib/api.js
+++ b/04_frontend_0222fb/src/lib/api.js
@@ -26,9 +26,6 @@ function resolveApiBaseUrl() {
   if (import.meta.env.DEV) {
     return import.meta.env.VITE_API_LOCAL_URL || 'http://127.0.0.1:8000'
   }
-  if (typeof window !== 'undefined' && window.location.hostname.endsWith('vercel.app')) {
-    return envUrl || 'https://btcreack20260222-fb.onrender.com'
-  }
   return envUrl || 'http://127.0.0.1:8000'
 }
 


### PR DESCRIPTION
## Summary
- `03_frontend`: sample 폴백 제거, API 에러 처리 단순화
- `04_frontend_0222fb`: 하드코딩된 구 Render URL 제거, `VITE_API_URL` 환경변수로 통일

## Vercel 대시보드 환경변수 설정 필요
```
VITE_API_URL=https://two0260317-alt.onrender.com
```

Closes #51