### PR TITLE
fix(pipeline): supabase 중복 설치 제거

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,7 +40,7 @@ jobs:
           cache: 'pip'
 
       - name: 패키지 설치
-        run: pip install -r ../requirements.txt supabase
+        run: pip install -r ../requirements.txt
 
       - name: 012 누락 데이터 업데이트
         run: python 012_cryptoCollectorUsdt_Update.py
@@ -64,7 +64,7 @@ jobs:
           cache: 'pip'
 
       - name: 패키지 설치
-        run: pip install -r ../requirements.txt supabase
+        run: pip install -r ../requirements.txt
 
       - name: 021 사이클 분석
         run: python 021_altCycleAnalysisUsdt.py

--- a/reports/55.md
+++ b/reports/55.md
@@ -1,0 +1,16 @@
+# #55 pipeline supabase 중복 설치 제거 보고서
+
+## 문제
+`pipeline.yml` collect/analyze job 모두 `pip install -r ../requirements.txt supabase` 형태로
+supabase를 중복 설치하고 있었음
+
+## 원인
+루트 `requirements.txt`에 `supabase>=2.4.0` 이미 포함되어 있음
+
+## 변경 내용
+- collect job: `supabase` 제거
+- analyze job: `supabase` 제거
+
+## 결과
+- PR 생성 및 main 머지
+- Closes #55


### PR DESCRIPTION
## Summary
- collect/analyze job 패키지 설치 명령에서 중복 `supabase` 제거
- 루트 `requirements.txt`에 이미 포함되어 있음

Closes #55