### PR TITLE
fix: duckdb 누락으로 인한 CI 예측 파이프라인 실패 수정

### DIFF
--- a/01_pairUSDT/032_train_and_predict_box.py
+++ b/01_pairUSDT/032_train_and_predict_box.py
@@ -301,13 +301,13 @@ def main():
     log.info("=" * 65)
     log.info("실행 모드: supabase")
     try:
-        reset_predictions_supabase()
-    except ValueError:
-        log.warning("Supabase 설정이 없어 reset_predictions_supabase를 건너뜁니다.")
-    try:
         import duckdb
     except ImportError as e:
         raise ImportError("duckdb 패키지가 필요합니다. pip install duckdb") from e
+    try:
+        reset_predictions_supabase()
+    except ValueError:
+        log.warning("Supabase 설정이 없어 reset_predictions_supabase를 건너뜁니다.")
     conn = duckdb.connect(database=":memory:")
     setup_stage_db_for_supabase(conn)
     hydrate_stage_db_from_supabase(conn)

--- a/reports/63.md
+++ b/reports/63.md
@@ -1,0 +1,26 @@
+# Issue #63 Report
+
+## What Was Found
+- The deployed endpoint `/api/predictions/bitcoin` returned `No predictions for coin_id=bitcoin`.
+- The prediction GitHub Action ran `032_train_and_predict_box.py` after installing `requirements_action_predict.txt`.
+- `duckdb` was missing from `requirements_action_predict.txt`.
+- `032_train_and_predict_box.py` cleared prediction tables before checking whether `duckdb` was importable.
+
+## What Was Changed
+- Added `duckdb>=1.0.0` to `requirements_action_predict.txt`.
+- Moved the `duckdb` import check before prediction-table reset in `01_pairUSDT/032_train_and_predict_box.py`.
+- Updated `unit_tests/01_pairUSDT/test_032_train_and_predict_box.py` to verify the reset path still runs after dependency setup.
+
+## Why
+- The prediction job must have `duckdb` installed in GitHub Actions.
+- If a dependency is missing, the script should fail before deleting existing prediction data.
+
+## Tests
+- `python -m pytest unit_tests/01_pairUSDT/test_032_train_and_predict_box.py -q --basetemp temp/pytest_032`
+  - `2 passed in 1.40s`
+- `python -m pytest unit_tests -q --basetemp temp/pytest_unit_tests`
+  - `50 passed in 2.07s`
+
+## PR
+- Issue: #63
+- Spec update: none

--- a/requirements_action_predict.txt
+++ b/requirements_action_predict.txt
@@ -4,5 +4,6 @@ numpy>=1.26.0
 pandas>=2.2.0
 scikit-learn>=1.4.0
 xgboost>=2.0.0
+duckdb>=1.0.0
 supabase>=2.4.0
 PyJWT>=2.8.0

--- a/unit_tests/01_pairUSDT/test_032_train_and_predict_box.py
+++ b/unit_tests/01_pairUSDT/test_032_train_and_predict_box.py
@@ -34,11 +34,15 @@ def test_032_normalize_rows_replaces_non_finite_values():
 
 def test_032_main_syncs_empty_predictions_without_training(monkeypatch):
     module = load_script_module("032_train_and_predict_box.py")
+    reset_calls = []
     sync_calls = []
     fake_conn = SimpleNamespace(close=lambda: None)
 
     monkeypatch.setitem(
         sys.modules, "duckdb", SimpleNamespace(connect=lambda database: fake_conn)
+    )
+    monkeypatch.setattr(
+        module, "reset_predictions_supabase", lambda: reset_calls.append(True)
     )
     monkeypatch.setattr(module, "setup_stage_db_for_supabase", lambda _conn: None)
     monkeypatch.setattr(module, "hydrate_stage_db_from_supabase", lambda _conn: None)
@@ -49,4 +53,5 @@ def test_032_main_syncs_empty_predictions_without_training(monkeypatch):
 
     module.main()
 
+    assert reset_calls == [True]
     assert sync_calls == [True]


### PR DESCRIPTION
## Summary
- `requirements_action_predict.txt`에 `duckdb>=1.0.0` 추가
- `pipeline-predict.yml`이 `main` 기준으로 실행되므로 duckdb 미포함 시 CI 실패
- `032_train_and_predict_box.py` 예측 데이터 생성 로직 복원

## Test plan
- [ ] `pipeline-predict.yml` 수동 실행(workflow_dispatch)으로 duckdb 설치 및 스크립트 정상 실행 확인

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)