### PR TITLE
fix: pipeline-predict 스케줄 매일 실행으로 변경

### DIFF
--- a/.github/workflows/pipeline-predict.yml
+++ b/.github/workflows/pipeline-predict.yml
@@ -2,8 +2,8 @@ name: Crypto Pipeline — Predict (032)
 
 on:
   schedule:
-    # 매주 월요일 01:00 UTC — 학습 및 예측 (032)
-    - cron: '0 1 * * 1'
+    # 매일 01:00 UTC — analyze(00:00 UTC) 실행 1시간 후
+    - cron: '0 1 * * *'
   workflow_dispatch:
 
 env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Applies to `01_pairUSDT/`.
 
 - Workflows live in `.github/workflows/`.
 - `pipeline-analyze.yml`: 012, 021, 031 실행 (매일 00:00 UTC)
-- `pipeline-predict.yml`: 032 실행 (매주 월요일 01:00 UTC)
+- `pipeline-predict.yml`: 032 실행 (매일 01:00 UTC — analyze 1시간 후)
 - Never hardcode secrets. Use repository or environment secrets.
 
 ---


### PR DESCRIPTION
## Summary
- `cron: '0 1 * * 1'` → `'0 1 * * *'` (매주 월요일 → 매일 01:00 UTC)
- analyze(00:00 UTC) 실행 1시간 후 predict 실행 보장
- AGENTS.md 스케줄 설명 동기화

Closes #65