### PR TITLE
Fix visualizer chart asset build

### DIFF
--- a/01_pairUSDT/033_visualizer_html.py
+++ b/01_pairUSDT/033_visualizer_html.py
@@ -272,7 +272,16 @@ def build_frontend_assets() -> bool:
         return False
 
     dist_dir = BASE_DIR / "templates" / "dist"
-    cmd = ["npx", "tsc", "-p", str(TS_CONFIG)]
+    cmd = [
+        "npx",
+        "tsc",
+        "-p",
+        str(TS_CONFIG),
+        "--rootDir",
+        "templates",
+        "--outDir",
+        "templates/dist",
+    ]
     print(f"[INFO] dist 갱신: {' '.join(cmd)}")
     try:
         result = subprocess.run(

--- a/01_pairUSDT/package.json
+++ b/01_pairUSDT/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build:ts": "esbuild templates/chart-logic.ts templates/chart-render.ts templates/chart-ui.ts templates/chart.ts --bundle=false --outdir=templates/dist --platform=browser --target=es2020",
+    "build:ts": "tsc -p tsconfig.frontend.json --rootDir templates --outDir templates/dist",
     "check:ts": "tsc -p tsconfig.frontend.json --noEmit"
   },
   "devDependencies": {

--- a/01_pairUSDT/templates/chart-ui.ts
+++ b/01_pairUSDT/templates/chart-ui.ts
@@ -1,9 +1,9 @@
 // UI interactions: coin list, buttons, search, toggles
 import { chartState } from './chart-logic.js';
 import { CYCLE_COLORS } from './chart-logic.js';
+import { drawChart } from './chart-draw.js';
 
 declare const ALL_DATA: any;
-declare function drawChart(): void;
 
 // ── Coin List UI ──────────────────────────────────────
 export function buildCoinList(filter: string = ''): void {

--- a/reports/67.md
+++ b/reports/67.md
@@ -1,0 +1,22 @@
+## What Was Found
+- `033_visualizer_html.html` included Supabase chart data, but the browser could not load `templates/dist/chart.js`.
+- The missing module caused the coin list and chart UI to remain uninitialized.
+- Toolbar buttons then failed with `toggleHighLow is not defined` and `toggleBoxZone is not defined`.
+
+## What Was Fixed
+- `01_pairUSDT/033_visualizer_html.py`: the visualizer TypeScript build now emits JS into `templates/dist`.
+- `01_pairUSDT/package.json`: `build:ts` now matches the Python visualizer build output path.
+- `01_pairUSDT/templates/chart-ui.ts`: imports `drawChart` directly instead of relying on a global declaration.
+
+## Why
+- The generated HTML expects `templates/dist/chart.js`.
+- Making both Python and npm builds emit to that path prevents the 404 and lets the module register UI behavior.
+- Importing `drawChart` keeps module dependencies explicit and avoids runtime global lookup failures.
+
+## Tests
+- `npm install`: passed.
+- `npm run build:ts`: passed.
+- `npm run check:ts`: passed.
+
+## PR
+- Issue #67 / spec update not required.


### PR DESCRIPTION
## Summary
- Fix 033 visualizer TypeScript build output so templates/dist/chart.js is generated.
- Align npm build script with the Python visualizer build path.
- Import drawChart directly for chart toolbar controls.

## Tests
- npm install
- npm run build:ts
- npm run check:ts

Closes #67