### PR TITLE
Harden 012 Binance backfill tests

### DIFF
--- a/reports/79.md
+++ b/reports/79.md
@@ -1,0 +1,36 @@
+# Issue #79 - 012 Binance Backfill Unit Test Hardening
+
+## What Changed
+
+Strengthened the unit tests for `012_cryptoCollectorUsdt_Update.py`.
+
+Updated `unit_tests/01_pairUSDT/test_012_cryptoCollectorUsdt_Update.py` to cover:
+
+- Empty-OHLCV coins call Binance with `from_date=None`.
+- Multiple empty-OHLCV coins are all backfilled.
+- Binance-only empty response behavior returns `[]` without fallback.
+- Parsed rows keep `source == "binance"`.
+- Today's unfinished candle is filtered out and not saved.
+- Removed the unused `pandas` import.
+
+## Why
+
+The previous tests verified the basic path, but they did not directly lock the most important backfill contract:
+
+- no existing OHLCV means full Binance history,
+- full history is represented by `from_date=None`,
+- every target coin is processed,
+- no CoinGecko fallback is used,
+- unfinished current-day candles are not persisted.
+
+## Tests
+
+- `python -m py_compile 01_pairUSDT/012_cryptoCollectorUsdt_Update.py`
+  - Passed
+- `python -m pytest unit_tests/01_pairUSDT/test_012_cryptoCollectorUsdt_Update.py -q`
+  - Passed: `8 passed`
+
+## Notes
+
+`python -m pytest unit_tests/01_pairUSDT -q` still has unrelated existing failures in `test_021_altCycleAnalysisUsdt.py`.
+Those failures are separate from this 012 test hardening work.

--- a/unit_tests/01_pairUSDT/test_012_cryptoCollectorUsdt_Update.py
+++ b/unit_tests/01_pairUSDT/test_012_cryptoCollectorUsdt_Update.py
@@ -3,8 +3,6 @@ import sys
 import uuid
 from pathlib import Path
 
-import pandas as pd
-
 
 PAIRUSDT_ROOT = Path(__file__).resolve().parents[2] / "01_pairUSDT"
 
@@ -18,6 +16,21 @@ def load_script_module(script_name: str):
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def make_kline(date_ms: int, close: str = "11") -> list:
+    return [
+        date_ms,
+        "10",
+        "12",
+        "9",
+        close,
+        "100",
+        date_ms + 86_399_999,
+        "1100",
+        7,
+    ]
+
 
 def test_012_next_date_advances_by_one_day():
     module = load_script_module("012_cryptoCollectorUsdt_Update.py")
@@ -66,6 +79,7 @@ def test_012_main_skips_already_up_to_date_coin(monkeypatch):
 
 def test_012_main_fetches_full_binance_history_when_ohlcv_is_empty(monkeypatch):
     module = load_script_module("012_cryptoCollectorUsdt_Update.py")
+    fetch_calls = []
     saved = []
 
     monkeypatch.setattr(module, "today_utc", lambda: "2026-04-03")
@@ -76,34 +90,14 @@ def test_012_main_fetches_full_binance_history_when_ohlcv_is_empty(monkeypatch):
         lambda _sb: [{"id": "zcash", "symbol": "ZEC", "name": "Zcash", "rank": 999}],
     )
     monkeypatch.setattr(module, "get_last_date_supabase", lambda *_args: None)
-    monkeypatch.setattr(
-        module,
-        "binance_fetch_klines",
-        lambda symbol, from_date=None: [
-            [
-                1775001600000,
-                "10",
-                "12",
-                "9",
-                "11",
-                "100",
-                1775087999999,
-                "1100",
-                7,
-            ],
-            [
-                1775174400000,
-                "11",
-                "13",
-                "10",
-                "12",
-                "101",
-                1775260799999,
-                "1212",
-                8,
-            ],
-        ],
-    )
+    def fake_fetch(symbol, from_date=None):
+        fetch_calls.append((symbol, from_date))
+        return [
+            make_kline(1775001600000),
+            make_kline(1775174400000, close="12"),
+        ]
+
+    monkeypatch.setattr(module, "binance_fetch_klines", fake_fetch)
 
     def fake_save(_supabase, coin_id, rows):
         saved.append((coin_id, rows))
@@ -113,12 +107,100 @@ def test_012_main_fetches_full_binance_history_when_ohlcv_is_empty(monkeypatch):
 
     module.main()
 
+    assert fetch_calls == [("ZEC", None)]
     assert len(saved) == 1
     assert saved[0][0] == "zcash"
     assert [row["date"] for row in saved[0][1]] == ["2026-04-01"]
 
 
-def test_012_update_uses_binance_only():
+def test_012_main_backfills_multiple_empty_ohlcv_coins(monkeypatch):
     module = load_script_module("012_cryptoCollectorUsdt_Update.py")
+    fetch_calls = []
+    saved = []
+
+    monkeypatch.setattr(module, "today_utc", lambda: "2026-04-03")
+    monkeypatch.setattr(module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(
+        module,
+        "get_coins_from_supabase",
+        lambda _sb: [
+            {"id": "zcash", "symbol": "ZEC", "name": "Zcash", "rank": 999},
+            {"id": "litecoin", "symbol": "LTC", "name": "Litecoin", "rank": 20},
+        ],
+    )
+    monkeypatch.setattr(module, "get_last_date_supabase", lambda *_args: None)
+
+    def fake_fetch(symbol, from_date=None):
+        fetch_calls.append((symbol, from_date))
+        return [make_kline(1775001600000)]
+
+    def fake_save(_supabase, coin_id, rows):
+        saved.append((coin_id, rows))
+        return len(rows)
+
+    monkeypatch.setattr(module, "binance_fetch_klines", fake_fetch)
+    monkeypatch.setattr(module, "save_rows_supabase", fake_save)
+
+    module.main()
+
+    assert fetch_calls == [("ZEC", None), ("LTC", None)]
+    assert [coin_id for coin_id, _rows in saved] == ["zcash", "litecoin"]
+
+
+def test_012_fetch_binance_rows_returns_empty_without_fallback(monkeypatch):
+    module = load_script_module("012_cryptoCollectorUsdt_Update.py")
+    calls = []
 
     assert not hasattr(module, "coingecko_fetch_daily_range")
+
+    def fake_fetch(symbol, from_date=None):
+        calls.append((symbol, from_date))
+        return []
+
+    monkeypatch.setattr(module, "binance_fetch_klines", fake_fetch)
+
+    assert module.fetch_binance_ohlcv_rows("ZEC", "2026-04-01") == []
+    assert calls == [("ZEC", "2026-04-01")]
+
+
+def test_012_fetch_binance_rows_sets_source_to_binance(monkeypatch):
+    module = load_script_module("012_cryptoCollectorUsdt_Update.py")
+
+    monkeypatch.setattr(
+        module,
+        "binance_fetch_klines",
+        lambda symbol, from_date=None: [make_kline(1775001600000)],
+    )
+
+    rows = module.fetch_binance_ohlcv_rows("ZEC", None)
+
+    assert rows[0]["source"] == "binance"
+
+
+def test_012_main_does_not_save_when_only_today_candle_is_returned(monkeypatch):
+    module = load_script_module("012_cryptoCollectorUsdt_Update.py")
+    save_calls = []
+
+    monkeypatch.setattr(module, "today_utc", lambda: "2026-04-03")
+    monkeypatch.setattr(module, "get_supabase_client", lambda: object())
+    monkeypatch.setattr(
+        module,
+        "get_coins_from_supabase",
+        lambda _sb: [{"id": "zcash", "symbol": "ZEC", "name": "Zcash", "rank": 999}],
+    )
+    monkeypatch.setattr(module, "get_last_date_supabase", lambda *_args: "2026-04-02")
+    monkeypatch.setattr(
+        module,
+        "binance_fetch_klines",
+        lambda symbol, from_date=None: [make_kline(1775174400000)],
+    )
+
+    def fake_save(*_args):
+        save_calls.append(_args)
+        raise AssertionError("should not save today's unfinished candle")
+
+    monkeypatch.setattr(module, "save_rows_supabase", fake_save)
+
+    module.main()
+
+    assert save_calls == []


### PR DESCRIPTION
## Summary
- Hardened 012 Binance backfill unit tests.
- Added assertions for `from_date=None`, multi-coin empty-OHLCV backfill, Binance-only empty responses, `source == binance`, and today's unfinished candle exclusion.
- Removed unused pandas import.

## Tests
- `python -m py_compile 01_pairUSDT/012_cryptoCollectorUsdt_Update.py`
- `python -m pytest unit_tests/01_pairUSDT/test_012_cryptoCollectorUsdt_Update.py -q`

Closes #79