### PR TITLE
Add extended forecast toggle

### DIFF
--- a/01_pairUSDT/templates/chart-logic.ts
+++ b/01_pairUSDT/templates/chart-logic.ts
@@ -115,6 +115,7 @@ const _state = {
   showBoxZone: true,
   showBearBull: false,
   showPrediction: true,
+  showExtendedForecast: false,
   bearBullLabels: [] as any[],
   boxMarkEls: [] as any[],
   boxMarksData: [] as BoxMarksEntry[],
@@ -144,6 +145,8 @@ export const chartState = {
   set showBearBull(v: boolean) { _state.showBearBull = v; },
   get showPrediction() { return _state.showPrediction; },
   set showPrediction(v: boolean) { _state.showPrediction = v; },
+  get showExtendedForecast() { return _state.showExtendedForecast; },
+  set showExtendedForecast(v: boolean) { _state.showExtendedForecast = v; },
   get boxMarkEls() { return _state.boxMarkEls; },
   set boxMarkEls(v: any[]) { _state.boxMarkEls = v; },
   get bearBullLabels() { return _state.bearBullLabels; },
@@ -527,6 +530,139 @@ export function getPhaseBoxStatsForSymbol(
 }
 
 // ── Lookup box info at given day (for tooltip) ────────
+export function getVisiblePredictionZoneIndexes(
+  zones: BoxZone[] | null | undefined,
+  cycleData: CyclePoint[] | null | undefined,
+): Set<number> {
+  const visible = new Set<number>();
+  if (!_state.showPrediction || !zones || zones.length === 0) {
+    return visible;
+  }
+  const predictionIndexes = zones
+    .map((z, idx) => ({ z, idx }))
+    .filter(({ z }) => z?.is_prediction === 1)
+    .sort((a, b) => {
+      const startDiff = Number(a.z.startX) - Number(b.z.startX);
+      return startDiff !== 0 ? startDiff : Number(a.z.endX) - Number(b.z.endX);
+    });
+  if (predictionIndexes.length === 0) {
+    return visible;
+  }
+  if (_state.showExtendedForecast) {
+    predictionIndexes.forEach(({ idx }) => visible.add(idx));
+    return visible;
+  }
+
+  const lastRealDay = cycleData && cycleData.length > 0
+    ? Number(cycleData[cycleData.length - 1]?.x)
+    : NaN;
+
+  const active = predictionIndexes.find(({ z }) => {
+    const result = String(z.result || '').toUpperCase();
+    const isActive = result === 'BEAR_ACTIVE' || result === 'BULL_ACTIVE' ||
+      result === 'PRED_BEAR_ACTIVE' || result === 'PRED_BULL_ACTIVE';
+    const containsLastReal = Number.isFinite(lastRealDay) &&
+      Number(z.startX) <= lastRealDay &&
+      lastRealDay <= Number(z.endX);
+    return isActive || containsLastReal;
+  });
+
+  if (active) {
+    visible.add(active.idx);
+  }
+
+  const activeOrder = active
+    ? predictionIndexes.findIndex(({ idx }) => idx === active.idx)
+    : -1;
+  const next = predictionIndexes.find(({ z }, order) => {
+    if (active && order <= activeOrder) {
+      return false;
+    }
+    return !Number.isFinite(lastRealDay) || Number(z.endX) >= lastRealDay;
+  });
+  if (next) {
+    visible.add(next.idx);
+  }
+
+  if (!active && !next) {
+    visible.add(predictionIndexes[0].idx);
+  }
+
+  return visible;
+}
+
+export function isZoneVisibleForPredictionScope(
+  zones: BoxZone[] | null | undefined,
+  cycleData: CyclePoint[] | null | undefined,
+  index: number,
+): boolean {
+  const z = zones?.[index];
+  if (!z || z.is_prediction !== 1) {
+    return true;
+  }
+  return getVisiblePredictionZoneIndexes(zones, cycleData).has(index);
+}
+
+export function getVisiblePredictionEndDay(
+  zones: BoxZone[] | null | undefined,
+  cycleData: CyclePoint[] | null | undefined,
+): number | null {
+  const ranges = getVisiblePredictionDayRanges(zones, cycleData);
+  if (ranges === null) {
+    return null;
+  }
+  let endDay: number | null = null;
+  ranges.forEach((range) => {
+    if (Number.isFinite(range.endX)) {
+      endDay = endDay == null ? range.endX : Math.max(endDay, range.endX);
+    }
+  });
+  return endDay;
+}
+
+export function getVisiblePredictionDayRanges(
+  zones: BoxZone[] | null | undefined,
+  cycleData: CyclePoint[] | null | undefined,
+): { startX: number; endX: number }[] | null {
+  if (!_state.showPrediction) {
+    return [];
+  }
+  const hasPredictionZones = !!zones?.some((z) => z?.is_prediction === 1);
+  if (!hasPredictionZones) {
+    return _state.showExtendedForecast ? null : [];
+  }
+  const visible = getVisiblePredictionZoneIndexes(zones, cycleData);
+  const ranges: { startX: number; endX: number }[] = [];
+  visible.forEach((idx) => {
+    const z = zones?.[idx];
+    const startX = Number(z?.startX);
+    const endX = Number(z?.endX);
+    if (Number.isFinite(startX) && Number.isFinite(endX)) {
+      ranges.push({ startX, endX });
+    }
+  });
+  return ranges.sort((a, b) => a.startX - b.startX || a.endX - b.endX);
+}
+
+export function isDayInVisiblePredictionScope(
+  day: number | null | undefined,
+  zones: BoxZone[] | null | undefined,
+  cycleData: CyclePoint[] | null | undefined,
+): boolean {
+  if (!_state.showPrediction) {
+    return false;
+  }
+  const dayNum = Number(day);
+  if (!Number.isFinite(dayNum)) {
+    return false;
+  }
+  const ranges = getVisiblePredictionDayRanges(zones, cycleData);
+  if (ranges === null) {
+    return true;
+  }
+  return ranges.some((range) => dayNum >= range.startX && dayNum <= range.endX);
+}
+
 export function findBoxAtDay(
   dayX: number,
   coinId: string,
@@ -541,8 +677,15 @@ export function findBoxAtDay(
   for (const bmd of _state.boxMarksData as any[]) {
     if (bmd.seriesKey !== `${coinId}_${cycleNum}_close`) continue;
     const firstBullZi = bmd.zones.findIndex((z: BoxZone) => z.phase === 'BULL');
+    const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(
+      bmd.zones,
+      bmd.cycleData,
+    );
     for (let zi = 0; zi < bmd.zones.length; zi++) {
       const z = bmd.zones[zi];
+      if (z.is_prediction === 1 && !visiblePredictionIndexes.has(zi)) {
+        continue;
+      }
       if (dayX >= z.startX && dayX <= z.endX) {
         const prev = bmd.zones[zi - 1] || null;
         const cycleLow = bmd.cycleData[bmd.cycleLowIdx]?.low ?? null;

--- a/01_pairUSDT/templates/chart-render-overlays.ts
+++ b/01_pairUSDT/templates/chart-render-overlays.ts
@@ -1,6 +1,6 @@
 // Overlay elements: box marks, bear/bull labels, cycle low & prediction markers
 import { chartState } from './chart-logic.js';
-import { getBtcAnchorInfo, getPhaseBoxStatsForSymbol, dayToTime, timeToDay, getScenarioKey, SCENARIO_STYLE } from './chart-logic.js';
+import { getBtcAnchorInfo, getPhaseBoxStatsForSymbol, dayToTime, timeToDay, getScenarioKey, SCENARIO_STYLE, getVisiblePredictionZoneIndexes, getVisiblePredictionDayRanges } from './chart-logic.js';
 
 type TooltipSegment = {
   type: 'BEAR' | 'BULL';
@@ -207,15 +207,62 @@ export function renderBoxMarks(
     placed.push(getLabelRectInOverlay(el));
   }
 
+  function addForecastGuide(day: number | null | undefined, label: string, kind: 'now' | 'forecast'): void {
+    const dayNum = Number(day);
+    if (!Number.isFinite(dayNum)) {
+      return;
+    }
+    let x = timeScale.timeToCoordinate(dayToTime(dayNum));
+    if (x === null) {
+      x = clampCoordToVisible(timeScale, dayNum, overlayWidth);
+    }
+    const guide = document.createElement('div');
+    guide.className = `forecast-guide ${kind}`;
+    guide.style.left = x + 'px';
+    guide.style.height = chartHeight + 'px';
+    overlay.appendChild(guide);
+    chartState.boxMarkEls.push(guide);
+
+    const guideLabel = document.createElement('div');
+    guideLabel.className = `forecast-guide-label ${kind}`;
+    guideLabel.textContent = label;
+    guideLabel.style.left = Math.max(44, Math.min(overlayWidth - 44, x)) + 'px';
+    guideLabel.style.top = '8px';
+    overlay.appendChild(guideLabel);
+    chartState.boxMarkEls.push(guideLabel);
+  }
+
   const btcAnchor = getBtcAnchorInfo(cycleNumber);
   const phaseBoxStats = getPhaseBoxStatsForSymbol(coinSymbol, 'BULL'); // BULL/Bear 모두 참고
   const isBtcChart = (coinSymbol || '').toUpperCase() === 'BTC';
+  const predictionScopeZones = zones.length > 0 ? zones : cycleRef?.box_zones || [];
+  const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(predictionScopeZones, cycleData);
+  const visiblePredictionDayRanges = getVisiblePredictionDayRanges(predictionScopeZones, cycleData);
+  const isVisiblePredictionDay = (day: any): boolean => {
+    const dayNum = Number(day);
+    if (!Number.isFinite(dayNum)) {
+      return false;
+    }
+    if (visiblePredictionDayRanges === null) {
+      return chartState.showPrediction;
+    }
+    return visiblePredictionDayRanges.some((range) => dayNum >= range.startX && dayNum <= range.endX);
+  };
+  const firstVisiblePrediction = Array.from(visiblePredictionIndexes)
+    .map((idx) => predictionScopeZones[idx])
+    .filter(Boolean)
+    .sort((a: any, b: any) => Number(a.startX) - Number(b.startX) || Number(a.endX) - Number(b.endX))[0];
+
+  if (chartState.showPrediction && visiblePredictionIndexes.size > 0) {
+    addForecastGuide(cycleData[cycleData.length - 1]?.x, 'NOW', 'now');
+    addForecastGuide(firstVisiblePrediction?.startX, 'FORECAST', 'forecast');
+  }
 
   if (chartState.showBoxZone && zones.length > 0) {
     zones.forEach((z: any, zi: number) => {
       const isBear = z.phase === 'BEAR';
       const isPrediction = z.is_prediction === 1; // 예측 박스 플래그
-      if (isPrediction && !chartState.showPrediction) {
+      if (isPrediction && !visiblePredictionIndexes.has(zi)) {
         return;
       }
       const result = String(z.result || '').toUpperCase();
@@ -782,6 +829,7 @@ export function renderBoxMarks(
   if (chartState.showPrediction && cycleRef && cycleRef.peak_predictions && cycleRef.peak_predictions.length > 0) {
     cycleRef.peak_predictions.forEach((p: any) => {
       const dayX = p.day_x;
+      if (!isVisiblePredictionDay(dayX)) return;
       if (p.value == null || !Number.isFinite(p.value)) return;
       let val = p.value;
       const maxDisp = 299.9;
@@ -833,11 +881,11 @@ export function renderBoxMarks(
 
   // prediction path end labels
   if (chartState.showPrediction && cycleRef && cycleRef.prediction_paths) {
-    const bullPts = cycleRef.prediction_paths.bull;
-    const bearPts = cycleRef.prediction_paths.bear;
+    const bullPts = cycleRef.prediction_paths.bull || [];
+    const bearPts = cycleRef.prediction_paths.bear || [];
     if (bullPts && bullPts.length > 1) {
       const lastU = bullPts[bullPts.length - 1];
-      if (lastU && lastU.value != null && Number.isFinite(lastU.value)) {
+      if (lastU && lastU.value != null && Number.isFinite(lastU.value) && isVisiblePredictionDay(lastU.x)) {
         const xU = timeScale.timeToCoordinate(dayToTime(lastU.x));
         if (xU == null) return;
         const yU = series.priceToCoordinate(lastU.value);
@@ -855,7 +903,7 @@ export function renderBoxMarks(
     }
     if (bearPts && bearPts.length > 1) {
       const lastB = bearPts[bearPts.length - 1];
-      if (lastB && lastB.value != null && Number.isFinite(lastB.value)) {
+      if (lastB && lastB.value != null && Number.isFinite(lastB.value) && isVisiblePredictionDay(lastB.x)) {
         const xEnd = timeScale.timeToCoordinate(dayToTime(lastB.x));
         if (xEnd == null) return;
         const yEnd = series.priceToCoordinate(lastB.value);

--- a/01_pairUSDT/templates/chart-series-boxzone.ts
+++ b/01_pairUSDT/templates/chart-series-boxzone.ts
@@ -1,6 +1,6 @@
 // ── Box zone series (hi/lo lines, fill area, active extension) ─────────────
 import { chartState } from './chart-logic.js';
-import { dayToTime, detectBoxZones } from './chart-logic.js';
+import { dayToTime, detectBoxZones, getVisiblePredictionZoneIndexes } from './chart-logic.js';
 import { setSeriesDataSafe, filterValidPoints } from './chart-series-helpers.js';
 import { renderBoxMarks } from './chart-render-overlays.js';
 
@@ -29,7 +29,7 @@ function getBoxZoneColors(
 ): { lineColor: string; fillTop: string; fillBot: string } {
   if (isPred) {
     const rgb = isBearBox ? '255,107,107' : '255,217,102';
-    return { lineColor: `rgba(${rgb},0.80)`, fillTop: `rgba(${rgb},0.10)`, fillBot: `rgba(${rgb},0.01)` };
+    return { lineColor: `rgba(${rgb},0.38)`, fillTop: `rgba(${rgb},0.075)`, fillBot: `rgba(${rgb},0.01)` };
   }
   const rgb = isBearBox ? '255,68,102' : '255,184,0';
   return { lineColor: `rgba(${rgb},0.85)`, fillTop: `rgba(${rgb},0.14)`, fillBot: `rgba(${rgb},0.04)` };
@@ -109,11 +109,11 @@ export function addBoxZoneSeries(
   }
   const hasDbZones = cycle.box_zones && cycle.box_zones.length > 0;
   const rawZones = hasDbZones ? cycle.box_zones : detectBoxZones(cycle.data);
-  const zones = chartState.showPrediction
-    ? rawZones
-    : rawZones.filter((z: any) => z.is_prediction !== 1);
+  const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(rawZones, cycle.data);
+  const zones = rawZones;
 
-  zones.forEach((z: any, zi: number) => {
+  rawZones.forEach((z: any, zi: number) => {
+    if (z.is_prediction === 1 && !visiblePredictionIndexes.has(zi)) return;
     if (!isValidZone(z)) return;
     const { lineColor, fillTop, fillBot } = getBoxZoneColors(z.is_prediction === 1, z.phase === 'BEAR');
     addBoxHiLoLines(z, zi, z.is_prediction === 1, lineColor, coinId, coinData, cycle, cycleNum);
@@ -155,8 +155,9 @@ export function addActiveBoxExtensions(
   if (!cycle.box_zones) return;
   const lastRealDay = cycle.data[cycle.data.length - 1]?.x ?? 0;
   const lastRealClose = cycle.data[cycle.data.length - 1]?.close ?? 100;
-  cycle.box_zones.forEach((z: any) => {
-    if (!chartState.showPrediction && z.is_prediction === 1) return;
+  const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(cycle.box_zones, cycle.data);
+  cycle.box_zones.forEach((z: any, zi: number) => {
+    if (z.is_prediction === 1 && !visiblePredictionIndexes.has(zi)) return;
     const result = String(z.result || '').toUpperCase();
     const isAct =
       result === 'BEAR_ACTIVE' || result === 'BULL_ACTIVE' ||

--- a/01_pairUSDT/templates/chart-series-prediction.ts
+++ b/01_pairUSDT/templates/chart-series-prediction.ts
@@ -1,6 +1,6 @@
 // ── Prediction path series (bull / bear dotted lines) ──────────────────────
 import { chartState } from './chart-logic.js';
-import { dayToTime, buildStepSeries, sanitizePathPoints } from './chart-logic.js';
+import { dayToTime, buildStepSeries, sanitizePathPoints, getVisiblePredictionDayRanges } from './chart-logic.js';
 import { setSeriesDataSafe, filterValidPoints } from './chart-series-helpers.js';
 
 declare const LightweightCharts: any;
@@ -28,7 +28,7 @@ function addSinglePathSeries(
 
   const pathSeries = chartState.chart.addLineSeries({
     color,
-    lineWidth: 2,
+    lineWidth: 1,
     lineStyle: LightweightCharts.LineStyle.Dotted,
     priceLineVisible: false,
     lastValueVisible: false,
@@ -49,19 +49,29 @@ export function addPredictionPaths(
 
   let bullPts = sanitizePathPoints(cycle.prediction_paths.bull || []);
   let bearPts = sanitizePathPoints(cycle.prediction_paths.bear || []);
+  const visibleRanges = getVisiblePredictionDayRanges(cycle.box_zones || [], cycle.data || []);
+  if (visibleRanges !== null) {
+    const isVisibleDay = (day: any) => {
+      const dayNum = Number(day);
+      return Number.isFinite(dayNum) &&
+        visibleRanges.some((range) => dayNum >= range.startX && dayNum <= range.endX);
+    };
+    bullPts = bullPts.filter((p: any) => isVisibleDay(p.x));
+    bearPts = bearPts.filter((p: any) => isVisibleDay(p.x));
+  }
 
   const meta = { coinId, symbol: coinData.symbol, cycleName: cycle.cycle_name, cycleNum };
 
   if (bullPts && bullPts.length > 1) {
     addSinglePathSeries(
-      bullPts, 'rgba(255,217,102,0.85)', 'pred_bull',
+      bullPts, 'rgba(255,217,102,0.36)', 'pred_bull',
       `${coinId}_${cycle.cycle_number}_path_bull`, meta,
     );
   }
 
   if (bearPts && bearPts.length > 1) {
     addSinglePathSeries(
-      bearPts, 'rgba(255,107,107,0.85)', 'pred_bear',
+      bearPts, 'rgba(255,107,107,0.36)', 'pred_bear',
       `${coinId}_${cycle.cycle_number}_path_bear`, meta,
     );
   }

--- a/01_pairUSDT/templates/chart-ui.ts
+++ b/01_pairUSDT/templates/chart-ui.ts
@@ -204,12 +204,35 @@ function toggleBoxZone() {
 
 function toggleBearBull() {
   chartState.showPrediction = !chartState.showPrediction;
+  if (!chartState.showPrediction) {
+    chartState.showExtendedForecast = false;
+  }
   const btn = document.getElementById('toggleBearBull') as HTMLButtonElement | null;
   if (btn) {
     btn.style.cssText = chartState.showPrediction
       ? 'border-color:#ff6bb5;color:#ff6bb5;background:rgba(255,107,181,0.1)'
       : 'border-color:#4a6080;color:#4a6080;';
   }
+  updateExtendedForecastButton();
+  drawChart();
+}
+
+function updateExtendedForecastButton(): void {
+  const btn = document.getElementById('toggleExtendedForecast') as HTMLButtonElement | null;
+  if (!btn) return;
+  btn.disabled = !chartState.showPrediction;
+  btn.style.cssText =
+    chartState.showPrediction && chartState.showExtendedForecast
+      ? 'border-color:#a78bfa;color:#d8ccff;background:rgba(167,139,250,0.12)'
+      : chartState.showPrediction
+      ? 'border-color:#4a6080;color:#4a6080;'
+      : 'border-color:#26364f;color:#344966;opacity:0.55;';
+}
+
+function toggleExtendedForecast() {
+  if (!chartState.showPrediction) return;
+  chartState.showExtendedForecast = !chartState.showExtendedForecast;
+  updateExtendedForecastButton();
   drawChart();
 }
 
@@ -251,6 +274,7 @@ export function initDefaults() {
       ? 'border-color:#ff6bb5;color:#ff6bb5;background:rgba(255,107,181,0.1)'
       : 'border-color:#4a6080;color:#4a6080;';
   }
+  updateExtendedForecastButton();
 }
 
 // ── Wire DOM events & expose toggles for onclick ───────
@@ -264,4 +288,5 @@ if (searchInput) {
 (window as any).toggleHighLow = toggleHighLow;
 (window as any).toggleBoxZone = toggleBoxZone;
 (window as any).toggleBearBull = toggleBearBull;
+(window as any).toggleExtendedForecast = toggleExtendedForecast;
 

--- a/01_pairUSDT/templates/chart.css
+++ b/01_pairUSDT/templates/chart.css
@@ -344,8 +344,37 @@
   .bz-label.bull { color: #FFB800; }
 
   /* 예측 박스 마크 (더 진하고 눈에 띄게) */
-  .bz-mark.prediction { opacity: 0.9; }
-  .bz-label.prediction { opacity: 0.95; font-style: italic; }
+  .bz-mark.prediction { opacity: 0.64; }
+  .bz-label.prediction { opacity: 0.68; font-style: italic; }
+
+  .forecast-guide {
+    position: absolute;
+    top: 0;
+    width: 0;
+    border-left: 1px dashed rgba(170, 190, 220, 0.48);
+    pointer-events: none;
+    z-index: 18;
+  }
+  .forecast-guide.forecast { border-left-color: rgba(255, 105, 180, 0.44); }
+  .forecast-guide-label {
+    position: absolute;
+    transform: translateX(-50%);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    pointer-events: none;
+    z-index: 24;
+    color: #c6d6f2;
+    background: rgba(7, 12, 22, 0.76);
+    border: 1px solid rgba(120, 145, 185, 0.35);
+  }
+  .forecast-guide-label.forecast {
+    color: #ff8fc7;
+    border-color: rgba(255, 105, 180, 0.38);
+  }
 
   /* 예측 경로 끝 라벨 */
   .pred-path-end {
@@ -355,6 +384,7 @@
     white-space: nowrap;
     pointer-events: none;
     z-index: 20;
+    opacity: 0.48;
   }
 
   /* 사이클 저점 마크: 큰 다이아몬드 */

--- a/01_pairUSDT/templates/chart.html
+++ b/01_pairUSDT/templates/chart.html
@@ -42,6 +42,9 @@
         <button class="cycle-btn" id="toggleBearBull"
           style="border-color:#ff6bb5;color:#ff6bb5;background:rgba(255,107,181,0.1)"
           onclick="toggleBearBull()">PREDICT</button>
+        <button class="cycle-btn" id="toggleExtendedForecast"
+          style="border-color:#4a6080;color:#4a6080;"
+          onclick="toggleExtendedForecast()">EXTENDED</button>
 
       </div>
     </div>

--- a/01_pairUSDT/templates/globals.d.ts
+++ b/01_pairUSDT/templates/globals.d.ts
@@ -37,6 +37,7 @@ declare let showHighLow: boolean;
 declare let showBoxZone: boolean;
 declare let showBearBull: boolean;
 declare let showPrediction: boolean;
+declare let showExtendedForecast: boolean;
 declare let seriesMap: Record<string, any>;
 declare let seriesMetaMap: Record<string, any>;
 

--- a/03_frontend/dist/legacy/chart-shell-v2.html
+++ b/03_frontend/dist/legacy/chart-shell-v2.html
@@ -31,6 +31,7 @@
         <button class="cycle-btn" id="toggleRange" onclick="toggleHighLow()">HIGH/LOW</button>
         <button class="cycle-btn" id="toggleBox" onclick="toggleBoxZone()">BOX ZONE</button>
         <button class="cycle-btn" id="toggleBearBull" onclick="toggleBearBull()">PREDICT</button>
+        <button class="cycle-btn" id="toggleExtendedForecast" onclick="toggleExtendedForecast()">EXTENDED</button>
       </div>
     </div>
 

--- a/03_frontend/dist/legacy/chart-v2.css
+++ b/03_frontend/dist/legacy/chart-v2.css
@@ -469,8 +469,40 @@ body {
 
 .bz-label.bear { color: #ff7f9f; }
 .bz-label.bull { color: #ffcf63; }
-.bz-mark.prediction { opacity: 0.9; }
-.bz-label.prediction { opacity: 0.96; font-style: italic; }
+.bz-mark.prediction { opacity: 0.64; }
+.bz-label.prediction { opacity: 0.68; font-style: italic; }
+
+.forecast-guide {
+  position: absolute;
+  top: 0;
+  width: 0;
+  border-left: 1px dashed rgba(170, 190, 220, 0.48);
+  pointer-events: none;
+  z-index: 18;
+}
+
+.forecast-guide.forecast { border-left-color: rgba(255, 105, 180, 0.44); }
+
+.forecast-guide-label {
+  position: absolute;
+  transform: translateX(-50%);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: 'Manrope', sans-serif;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 1px;
+  pointer-events: none;
+  z-index: 24;
+  color: #c6d6f2;
+  background: rgba(7, 12, 22, 0.76);
+  border: 1px solid rgba(120, 145, 185, 0.35);
+}
+
+.forecast-guide-label.forecast {
+  color: #ff8fc7;
+  border-color: rgba(255, 105, 180, 0.38);
+}
 
 .pred-path-end {
   position: absolute;
@@ -479,6 +511,7 @@ body {
   white-space: nowrap;
   font-size: 0.76rem;
   font-weight: 700;
+  opacity: 0.48;
 }
 
 .cycle-low-mark {

--- a/03_frontend/dist/legacy/dist/chart-logic.js
+++ b/03_frontend/dist/legacy/dist/chart-logic.js
@@ -72,6 +72,7 @@ const _state = {
     showBoxZone: true,
     showBearBull: false,
     showPrediction: true,
+    showExtendedForecast: false,
     bearBullLabels: [],
     boxMarkEls: [],
     boxMarksData: [],
@@ -100,6 +101,8 @@ export const chartState = {
     set showBearBull(v) { _state.showBearBull = v; },
     get showPrediction() { return _state.showPrediction; },
     set showPrediction(v) { _state.showPrediction = v; },
+    get showExtendedForecast() { return _state.showExtendedForecast; },
+    set showExtendedForecast(v) { _state.showExtendedForecast = v; },
     get boxMarkEls() { return _state.boxMarkEls; },
     set boxMarkEls(v) { _state.boxMarkEls = v; },
     get bearBullLabels() { return _state.bearBullLabels; },
@@ -440,13 +443,122 @@ export function getPhaseBoxStatsForSymbol(symbol, phase) {
     return { avg, max };
 }
 // ── Lookup box info at given day (for tooltip) ────────
+export function getVisiblePredictionZoneIndexes(zones, cycleData) {
+    const visible = new Set();
+    if (!_state.showPrediction || !zones || zones.length === 0) {
+        return visible;
+    }
+    const predictionIndexes = zones
+        .map((z, idx) => ({ z, idx }))
+        .filter(({ z }) => z?.is_prediction === 1)
+        .sort((a, b) => {
+        const startDiff = Number(a.z.startX) - Number(b.z.startX);
+        return startDiff !== 0 ? startDiff : Number(a.z.endX) - Number(b.z.endX);
+    });
+    if (predictionIndexes.length === 0) {
+        return visible;
+    }
+    if (_state.showExtendedForecast) {
+        predictionIndexes.forEach(({ idx }) => visible.add(idx));
+        return visible;
+    }
+    const lastRealDay = cycleData && cycleData.length > 0
+        ? Number(cycleData[cycleData.length - 1]?.x)
+        : NaN;
+    const active = predictionIndexes.find(({ z }) => {
+        const result = String(z.result || '').toUpperCase();
+        const isActive = result === 'BEAR_ACTIVE' || result === 'BULL_ACTIVE' ||
+            result === 'PRED_BEAR_ACTIVE' || result === 'PRED_BULL_ACTIVE';
+        const containsLastReal = Number.isFinite(lastRealDay) &&
+            Number(z.startX) <= lastRealDay &&
+            lastRealDay <= Number(z.endX);
+        return isActive || containsLastReal;
+    });
+    if (active) {
+        visible.add(active.idx);
+    }
+    const activeOrder = active
+        ? predictionIndexes.findIndex(({ idx }) => idx === active.idx)
+        : -1;
+    const next = predictionIndexes.find(({ z }, order) => {
+        if (active && order <= activeOrder) {
+            return false;
+        }
+        return !Number.isFinite(lastRealDay) || Number(z.endX) >= lastRealDay;
+    });
+    if (next) {
+        visible.add(next.idx);
+    }
+    if (!active && !next) {
+        visible.add(predictionIndexes[0].idx);
+    }
+    return visible;
+}
+export function isZoneVisibleForPredictionScope(zones, cycleData, index) {
+    const z = zones?.[index];
+    if (!z || z.is_prediction !== 1) {
+        return true;
+    }
+    return getVisiblePredictionZoneIndexes(zones, cycleData).has(index);
+}
+export function getVisiblePredictionEndDay(zones, cycleData) {
+    const ranges = getVisiblePredictionDayRanges(zones, cycleData);
+    if (ranges === null) {
+        return null;
+    }
+    let endDay = null;
+    ranges.forEach((range) => {
+        if (Number.isFinite(range.endX)) {
+            endDay = endDay == null ? range.endX : Math.max(endDay, range.endX);
+        }
+    });
+    return endDay;
+}
+export function getVisiblePredictionDayRanges(zones, cycleData) {
+    if (!_state.showPrediction) {
+        return [];
+    }
+    const hasPredictionZones = !!zones?.some((z) => z?.is_prediction === 1);
+    if (!hasPredictionZones) {
+        return _state.showExtendedForecast ? null : [];
+    }
+    const visible = getVisiblePredictionZoneIndexes(zones, cycleData);
+    const ranges = [];
+    visible.forEach((idx) => {
+        const z = zones?.[idx];
+        const startX = Number(z?.startX);
+        const endX = Number(z?.endX);
+        if (Number.isFinite(startX) && Number.isFinite(endX)) {
+            ranges.push({ startX, endX });
+        }
+    });
+    return ranges.sort((a, b) => a.startX - b.startX || a.endX - b.endX);
+}
+export function isDayInVisiblePredictionScope(day, zones, cycleData) {
+    if (!_state.showPrediction) {
+        return false;
+    }
+    const dayNum = Number(day);
+    if (!Number.isFinite(dayNum)) {
+        return false;
+    }
+    const ranges = getVisiblePredictionDayRanges(zones, cycleData);
+    if (ranges === null) {
+        return true;
+    }
+    return ranges.some((range) => dayNum >= range.startX && dayNum <= range.endX);
+}
 export function findBoxAtDay(dayX, coinId, cycleNum) {
     for (const bmd of _state.boxMarksData) {
         if (bmd.seriesKey !== `${coinId}_${cycleNum}_close`)
             continue;
         const firstBullZi = bmd.zones.findIndex((z) => z.phase === 'BULL');
+        const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(bmd.zones, bmd.cycleData);
         for (let zi = 0; zi < bmd.zones.length; zi++) {
             const z = bmd.zones[zi];
+            if (z.is_prediction === 1 && !visiblePredictionIndexes.has(zi)) {
+                continue;
+            }
             if (dayX >= z.startX && dayX <= z.endX) {
                 const prev = bmd.zones[zi - 1] || null;
                 const cycleLow = bmd.cycleData[bmd.cycleLowIdx]?.low ?? null;

--- a/03_frontend/dist/legacy/dist/chart-render-overlays.js
+++ b/03_frontend/dist/legacy/dist/chart-render-overlays.js
@@ -1,6 +1,6 @@
 // Overlay elements: box marks, bear/bull labels, cycle low & prediction markers
 import { chartState } from './chart-logic.js';
-import { getBtcAnchorInfo, getPhaseBoxStatsForSymbol, dayToTime, timeToDay, getScenarioKey, SCENARIO_STYLE } from './chart-logic.js';
+import { getBtcAnchorInfo, getPhaseBoxStatsForSymbol, dayToTime, timeToDay, getScenarioKey, SCENARIO_STYLE, getVisiblePredictionZoneIndexes, getVisiblePredictionDayRanges } from './chart-logic.js';
 function normalizedRateToUsd(rate, cycleRef) {
     const basePrice = Number(cycleRef?.peak_price);
     const normalizedRate = Number(rate);
@@ -160,14 +160,58 @@ export function renderBoxMarks(zones, cycleLowIdx, cycleData, timeScale, series,
         }
         placed.push(getLabelRectInOverlay(el));
     }
+    function addForecastGuide(day, label, kind) {
+        const dayNum = Number(day);
+        if (!Number.isFinite(dayNum)) {
+            return;
+        }
+        let x = timeScale.timeToCoordinate(dayToTime(dayNum));
+        if (x === null) {
+            x = clampCoordToVisible(timeScale, dayNum, overlayWidth);
+        }
+        const guide = document.createElement('div');
+        guide.className = `forecast-guide ${kind}`;
+        guide.style.left = x + 'px';
+        guide.style.height = chartHeight + 'px';
+        overlay.appendChild(guide);
+        chartState.boxMarkEls.push(guide);
+        const guideLabel = document.createElement('div');
+        guideLabel.className = `forecast-guide-label ${kind}`;
+        guideLabel.textContent = label;
+        guideLabel.style.left = Math.max(44, Math.min(overlayWidth - 44, x)) + 'px';
+        guideLabel.style.top = '8px';
+        overlay.appendChild(guideLabel);
+        chartState.boxMarkEls.push(guideLabel);
+    }
     const btcAnchor = getBtcAnchorInfo(cycleNumber);
     const phaseBoxStats = getPhaseBoxStatsForSymbol(coinSymbol, 'BULL'); // BULL/Bear 모두 참고
     const isBtcChart = (coinSymbol || '').toUpperCase() === 'BTC';
+    const predictionScopeZones = zones.length > 0 ? zones : cycleRef?.box_zones || [];
+    const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(predictionScopeZones, cycleData);
+    const visiblePredictionDayRanges = getVisiblePredictionDayRanges(predictionScopeZones, cycleData);
+    const isVisiblePredictionDay = (day) => {
+        const dayNum = Number(day);
+        if (!Number.isFinite(dayNum)) {
+            return false;
+        }
+        if (visiblePredictionDayRanges === null) {
+            return chartState.showPrediction;
+        }
+        return visiblePredictionDayRanges.some((range) => dayNum >= range.startX && dayNum <= range.endX);
+    };
+    const firstVisiblePrediction = Array.from(visiblePredictionIndexes)
+        .map((idx) => predictionScopeZones[idx])
+        .filter(Boolean)
+        .sort((a, b) => Number(a.startX) - Number(b.startX) || Number(a.endX) - Number(b.endX))[0];
+    if (chartState.showPrediction && visiblePredictionIndexes.size > 0) {
+        addForecastGuide(cycleData[cycleData.length - 1]?.x, 'NOW', 'now');
+        addForecastGuide(firstVisiblePrediction?.startX, 'FORECAST', 'forecast');
+    }
     if (chartState.showBoxZone && zones.length > 0) {
         zones.forEach((z, zi) => {
             const isBear = z.phase === 'BEAR';
             const isPrediction = z.is_prediction === 1; // 예측 박스 플래그
-            if (isPrediction && !chartState.showPrediction) {
+            if (isPrediction && !visiblePredictionIndexes.has(zi)) {
                 return;
             }
             const result = String(z.result || '').toUpperCase();
@@ -688,6 +732,8 @@ export function renderBoxMarks(zones, cycleLowIdx, cycleData, timeScale, series,
     if (chartState.showPrediction && cycleRef && cycleRef.peak_predictions && cycleRef.peak_predictions.length > 0) {
         cycleRef.peak_predictions.forEach((p) => {
             const dayX = p.day_x;
+            if (!isVisiblePredictionDay(dayX))
+                return;
             if (p.value == null || !Number.isFinite(p.value))
                 return;
             let val = p.value;
@@ -742,11 +788,11 @@ export function renderBoxMarks(zones, cycleLowIdx, cycleData, timeScale, series,
     }
     // prediction path end labels
     if (chartState.showPrediction && cycleRef && cycleRef.prediction_paths) {
-        const bullPts = cycleRef.prediction_paths.bull;
-        const bearPts = cycleRef.prediction_paths.bear;
+        const bullPts = cycleRef.prediction_paths.bull || [];
+        const bearPts = cycleRef.prediction_paths.bear || [];
         if (bullPts && bullPts.length > 1) {
             const lastU = bullPts[bullPts.length - 1];
-            if (lastU && lastU.value != null && Number.isFinite(lastU.value)) {
+            if (lastU && lastU.value != null && Number.isFinite(lastU.value) && isVisiblePredictionDay(lastU.x)) {
                 const xU = timeScale.timeToCoordinate(dayToTime(lastU.x));
                 if (xU == null)
                     return;
@@ -765,7 +811,7 @@ export function renderBoxMarks(zones, cycleLowIdx, cycleData, timeScale, series,
         }
         if (bearPts && bearPts.length > 1) {
             const lastB = bearPts[bearPts.length - 1];
-            if (lastB && lastB.value != null && Number.isFinite(lastB.value)) {
+            if (lastB && lastB.value != null && Number.isFinite(lastB.value) && isVisiblePredictionDay(lastB.x)) {
                 const xEnd = timeScale.timeToCoordinate(dayToTime(lastB.x));
                 if (xEnd == null)
                     return;

--- a/03_frontend/dist/legacy/dist/chart-series-boxzone.js
+++ b/03_frontend/dist/legacy/dist/chart-series-boxzone.js
@@ -1,6 +1,6 @@
 // ── Box zone series (hi/lo lines, fill area, active extension) ─────────────
 import { chartState } from './chart-logic.js';
-import { dayToTime, detectBoxZones } from './chart-logic.js';
+import { dayToTime, detectBoxZones, getVisiblePredictionZoneIndexes } from './chart-logic.js';
 import { setSeriesDataSafe, filterValidPoints } from './chart-series-helpers.js';
 import { renderBoxMarks } from './chart-render-overlays.js';
 // z.hi / z.lo / z.startX / z.endX 가 하나라도 NaN/null 이면 skip
@@ -20,7 +20,7 @@ function safePrice(val, fallback = 0) {
 function getBoxZoneColors(isPred, isBearBox) {
     if (isPred) {
         const rgb = isBearBox ? '255,107,107' : '255,217,102';
-        return { lineColor: `rgba(${rgb},0.80)`, fillTop: `rgba(${rgb},0.10)`, fillBot: `rgba(${rgb},0.01)` };
+        return { lineColor: `rgba(${rgb},0.38)`, fillTop: `rgba(${rgb},0.075)`, fillBot: `rgba(${rgb},0.01)` };
     }
     const rgb = isBearBox ? '255,68,102' : '255,184,0';
     return { lineColor: `rgba(${rgb},0.85)`, fillTop: `rgba(${rgb},0.14)`, fillBot: `rgba(${rgb},0.04)` };
@@ -86,10 +86,11 @@ export function addBoxZoneSeries(coinId, coinData, cycle, cycleNum, cycleMinLowI
     }
     const hasDbZones = cycle.box_zones && cycle.box_zones.length > 0;
     const rawZones = hasDbZones ? cycle.box_zones : detectBoxZones(cycle.data);
-    const zones = chartState.showPrediction
-        ? rawZones
-        : rawZones.filter((z) => z.is_prediction !== 1);
-    zones.forEach((z, zi) => {
+    const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(rawZones, cycle.data);
+    const zones = rawZones;
+    rawZones.forEach((z, zi) => {
+        if (z.is_prediction === 1 && !visiblePredictionIndexes.has(zi))
+            return;
         if (!isValidZone(z))
             return;
         const { lineColor, fillTop, fillBot } = getBoxZoneColors(z.is_prediction === 1, z.phase === 'BEAR');
@@ -126,8 +127,9 @@ export function addActiveBoxExtensions(coinId, coinData, cycle, cycleNum) {
         return;
     const lastRealDay = cycle.data[cycle.data.length - 1]?.x ?? 0;
     const lastRealClose = cycle.data[cycle.data.length - 1]?.close ?? 100;
-    cycle.box_zones.forEach((z) => {
-        if (!chartState.showPrediction && z.is_prediction === 1)
+    const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(cycle.box_zones, cycle.data);
+    cycle.box_zones.forEach((z, zi) => {
+        if (z.is_prediction === 1 && !visiblePredictionIndexes.has(zi))
             return;
         const result = String(z.result || '').toUpperCase();
         const isAct = result === 'BEAR_ACTIVE' || result === 'BULL_ACTIVE' ||

--- a/03_frontend/dist/legacy/dist/chart-series-prediction.js
+++ b/03_frontend/dist/legacy/dist/chart-series-prediction.js
@@ -1,6 +1,6 @@
 // ── Prediction path series (bull / bear dotted lines) ──────────────────────
 import { chartState } from './chart-logic.js';
-import { dayToTime, buildStepSeries, sanitizePathPoints } from './chart-logic.js';
+import { dayToTime, buildStepSeries, sanitizePathPoints, getVisiblePredictionDayRanges } from './chart-logic.js';
 import { setSeriesDataSafe, filterValidPoints } from './chart-series-helpers.js';
 function buildPathLinePoints(rawPts) {
     return rawPts
@@ -18,7 +18,7 @@ function addSinglePathSeries(pts, color, kind, seriesKey, meta) {
     const seriesData = buildStepSeries(linePoints);
     const pathSeries = chartState.chart.addLineSeries({
         color,
-        lineWidth: 2,
+        lineWidth: 1,
         lineStyle: LightweightCharts.LineStyle.Dotted,
         priceLineVisible: false,
         lastValueVisible: false,
@@ -34,11 +34,21 @@ export function addPredictionPaths(coinId, coinData, cycle, cycleNum) {
         return;
     let bullPts = sanitizePathPoints(cycle.prediction_paths.bull || []);
     let bearPts = sanitizePathPoints(cycle.prediction_paths.bear || []);
+    const visibleRanges = getVisiblePredictionDayRanges(cycle.box_zones || [], cycle.data || []);
+    if (visibleRanges !== null) {
+        const isVisibleDay = (day) => {
+            const dayNum = Number(day);
+            return Number.isFinite(dayNum) &&
+                visibleRanges.some((range) => dayNum >= range.startX && dayNum <= range.endX);
+        };
+        bullPts = bullPts.filter((p) => isVisibleDay(p.x));
+        bearPts = bearPts.filter((p) => isVisibleDay(p.x));
+    }
     const meta = { coinId, symbol: coinData.symbol, cycleName: cycle.cycle_name, cycleNum };
     if (bullPts && bullPts.length > 1) {
-        addSinglePathSeries(bullPts, 'rgba(255,217,102,0.85)', 'pred_bull', `${coinId}_${cycle.cycle_number}_path_bull`, meta);
+        addSinglePathSeries(bullPts, 'rgba(255,217,102,0.36)', 'pred_bull', `${coinId}_${cycle.cycle_number}_path_bull`, meta);
     }
     if (bearPts && bearPts.length > 1) {
-        addSinglePathSeries(bearPts, 'rgba(255,107,107,0.85)', 'pred_bear', `${coinId}_${cycle.cycle_number}_path_bear`, meta);
+        addSinglePathSeries(bearPts, 'rgba(255,107,107,0.36)', 'pred_bear', `${coinId}_${cycle.cycle_number}_path_bear`, meta);
     }
 }

--- a/03_frontend/dist/legacy/dist/chart-ui.js
+++ b/03_frontend/dist/legacy/dist/chart-ui.js
@@ -181,12 +181,35 @@ function toggleBoxZone() {
 }
 function toggleBearBull() {
     chartState.showPrediction = !chartState.showPrediction;
+    if (!chartState.showPrediction) {
+        chartState.showExtendedForecast = false;
+    }
     const btn = document.getElementById('toggleBearBull');
     if (btn) {
         btn.style.cssText = chartState.showPrediction
             ? 'border-color:#ff6bb5;color:#ff6bb5;background:rgba(255,107,181,0.1)'
             : 'border-color:#4a6080;color:#4a6080;';
     }
+    updateExtendedForecastButton();
+    drawChart();
+}
+function updateExtendedForecastButton() {
+    const btn = document.getElementById('toggleExtendedForecast');
+    if (!btn)
+        return;
+    btn.disabled = !chartState.showPrediction;
+    btn.style.cssText =
+        chartState.showPrediction && chartState.showExtendedForecast
+            ? 'border-color:#a78bfa;color:#d8ccff;background:rgba(167,139,250,0.12)'
+            : chartState.showPrediction
+                ? 'border-color:#4a6080;color:#4a6080;'
+                : 'border-color:#26364f;color:#344966;opacity:0.55;';
+}
+function toggleExtendedForecast() {
+    if (!chartState.showPrediction)
+        return;
+    chartState.showExtendedForecast = !chartState.showExtendedForecast;
+    updateExtendedForecastButton();
     drawChart();
 }
 // ── Defaults & Bottom Override UI ─────────────────────
@@ -224,6 +247,7 @@ export function initDefaults() {
             ? 'border-color:#ff6bb5;color:#ff6bb5;background:rgba(255,107,181,0.1)'
             : 'border-color:#4a6080;color:#4a6080;';
     }
+    updateExtendedForecastButton();
 }
 // ── Wire DOM events & expose toggles for onclick ───────
 const searchInput = document.getElementById('searchInput');
@@ -236,3 +260,4 @@ if (searchInput) {
 window.toggleHighLow = toggleHighLow;
 window.toggleBoxZone = toggleBoxZone;
 window.toggleBearBull = toggleBearBull;
+window.toggleExtendedForecast = toggleExtendedForecast;

--- a/03_frontend/public/legacy/chart-shell-v2.html
+++ b/03_frontend/public/legacy/chart-shell-v2.html
@@ -31,6 +31,7 @@
         <button class="cycle-btn" id="toggleRange" onclick="toggleHighLow()">HIGH/LOW</button>
         <button class="cycle-btn" id="toggleBox" onclick="toggleBoxZone()">BOX ZONE</button>
         <button class="cycle-btn" id="toggleBearBull" onclick="toggleBearBull()">PREDICT</button>
+        <button class="cycle-btn" id="toggleExtendedForecast" onclick="toggleExtendedForecast()">EXTENDED</button>
       </div>
     </div>
 

--- a/03_frontend/public/legacy/chart-v2.css
+++ b/03_frontend/public/legacy/chart-v2.css
@@ -469,8 +469,40 @@ body {
 
 .bz-label.bear { color: #ff7f9f; }
 .bz-label.bull { color: #ffcf63; }
-.bz-mark.prediction { opacity: 0.9; }
-.bz-label.prediction { opacity: 0.96; font-style: italic; }
+.bz-mark.prediction { opacity: 0.64; }
+.bz-label.prediction { opacity: 0.68; font-style: italic; }
+
+.forecast-guide {
+  position: absolute;
+  top: 0;
+  width: 0;
+  border-left: 1px dashed rgba(170, 190, 220, 0.48);
+  pointer-events: none;
+  z-index: 18;
+}
+
+.forecast-guide.forecast { border-left-color: rgba(255, 105, 180, 0.44); }
+
+.forecast-guide-label {
+  position: absolute;
+  transform: translateX(-50%);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: 'Manrope', sans-serif;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 1px;
+  pointer-events: none;
+  z-index: 24;
+  color: #c6d6f2;
+  background: rgba(7, 12, 22, 0.76);
+  border: 1px solid rgba(120, 145, 185, 0.35);
+}
+
+.forecast-guide-label.forecast {
+  color: #ff8fc7;
+  border-color: rgba(255, 105, 180, 0.38);
+}
 
 .pred-path-end {
   position: absolute;
@@ -479,6 +511,7 @@ body {
   white-space: nowrap;
   font-size: 0.76rem;
   font-weight: 700;
+  opacity: 0.48;
 }
 
 .cycle-low-mark {

--- a/03_frontend/public/legacy/dist/chart-logic.js
+++ b/03_frontend/public/legacy/dist/chart-logic.js
@@ -72,6 +72,7 @@ const _state = {
     showBoxZone: true,
     showBearBull: false,
     showPrediction: true,
+    showExtendedForecast: false,
     bearBullLabels: [],
     boxMarkEls: [],
     boxMarksData: [],
@@ -100,6 +101,8 @@ export const chartState = {
     set showBearBull(v) { _state.showBearBull = v; },
     get showPrediction() { return _state.showPrediction; },
     set showPrediction(v) { _state.showPrediction = v; },
+    get showExtendedForecast() { return _state.showExtendedForecast; },
+    set showExtendedForecast(v) { _state.showExtendedForecast = v; },
     get boxMarkEls() { return _state.boxMarkEls; },
     set boxMarkEls(v) { _state.boxMarkEls = v; },
     get bearBullLabels() { return _state.bearBullLabels; },
@@ -440,13 +443,122 @@ export function getPhaseBoxStatsForSymbol(symbol, phase) {
     return { avg, max };
 }
 // ── Lookup box info at given day (for tooltip) ────────
+export function getVisiblePredictionZoneIndexes(zones, cycleData) {
+    const visible = new Set();
+    if (!_state.showPrediction || !zones || zones.length === 0) {
+        return visible;
+    }
+    const predictionIndexes = zones
+        .map((z, idx) => ({ z, idx }))
+        .filter(({ z }) => z?.is_prediction === 1)
+        .sort((a, b) => {
+        const startDiff = Number(a.z.startX) - Number(b.z.startX);
+        return startDiff !== 0 ? startDiff : Number(a.z.endX) - Number(b.z.endX);
+    });
+    if (predictionIndexes.length === 0) {
+        return visible;
+    }
+    if (_state.showExtendedForecast) {
+        predictionIndexes.forEach(({ idx }) => visible.add(idx));
+        return visible;
+    }
+    const lastRealDay = cycleData && cycleData.length > 0
+        ? Number(cycleData[cycleData.length - 1]?.x)
+        : NaN;
+    const active = predictionIndexes.find(({ z }) => {
+        const result = String(z.result || '').toUpperCase();
+        const isActive = result === 'BEAR_ACTIVE' || result === 'BULL_ACTIVE' ||
+            result === 'PRED_BEAR_ACTIVE' || result === 'PRED_BULL_ACTIVE';
+        const containsLastReal = Number.isFinite(lastRealDay) &&
+            Number(z.startX) <= lastRealDay &&
+            lastRealDay <= Number(z.endX);
+        return isActive || containsLastReal;
+    });
+    if (active) {
+        visible.add(active.idx);
+    }
+    const activeOrder = active
+        ? predictionIndexes.findIndex(({ idx }) => idx === active.idx)
+        : -1;
+    const next = predictionIndexes.find(({ z }, order) => {
+        if (active && order <= activeOrder) {
+            return false;
+        }
+        return !Number.isFinite(lastRealDay) || Number(z.endX) >= lastRealDay;
+    });
+    if (next) {
+        visible.add(next.idx);
+    }
+    if (!active && !next) {
+        visible.add(predictionIndexes[0].idx);
+    }
+    return visible;
+}
+export function isZoneVisibleForPredictionScope(zones, cycleData, index) {
+    const z = zones?.[index];
+    if (!z || z.is_prediction !== 1) {
+        return true;
+    }
+    return getVisiblePredictionZoneIndexes(zones, cycleData).has(index);
+}
+export function getVisiblePredictionEndDay(zones, cycleData) {
+    const ranges = getVisiblePredictionDayRanges(zones, cycleData);
+    if (ranges === null) {
+        return null;
+    }
+    let endDay = null;
+    ranges.forEach((range) => {
+        if (Number.isFinite(range.endX)) {
+            endDay = endDay == null ? range.endX : Math.max(endDay, range.endX);
+        }
+    });
+    return endDay;
+}
+export function getVisiblePredictionDayRanges(zones, cycleData) {
+    if (!_state.showPrediction) {
+        return [];
+    }
+    const hasPredictionZones = !!zones?.some((z) => z?.is_prediction === 1);
+    if (!hasPredictionZones) {
+        return _state.showExtendedForecast ? null : [];
+    }
+    const visible = getVisiblePredictionZoneIndexes(zones, cycleData);
+    const ranges = [];
+    visible.forEach((idx) => {
+        const z = zones?.[idx];
+        const startX = Number(z?.startX);
+        const endX = Number(z?.endX);
+        if (Number.isFinite(startX) && Number.isFinite(endX)) {
+            ranges.push({ startX, endX });
+        }
+    });
+    return ranges.sort((a, b) => a.startX - b.startX || a.endX - b.endX);
+}
+export function isDayInVisiblePredictionScope(day, zones, cycleData) {
+    if (!_state.showPrediction) {
+        return false;
+    }
+    const dayNum = Number(day);
+    if (!Number.isFinite(dayNum)) {
+        return false;
+    }
+    const ranges = getVisiblePredictionDayRanges(zones, cycleData);
+    if (ranges === null) {
+        return true;
+    }
+    return ranges.some((range) => dayNum >= range.startX && dayNum <= range.endX);
+}
 export function findBoxAtDay(dayX, coinId, cycleNum) {
     for (const bmd of _state.boxMarksData) {
         if (bmd.seriesKey !== `${coinId}_${cycleNum}_close`)
             continue;
         const firstBullZi = bmd.zones.findIndex((z) => z.phase === 'BULL');
+        const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(bmd.zones, bmd.cycleData);
         for (let zi = 0; zi < bmd.zones.length; zi++) {
             const z = bmd.zones[zi];
+            if (z.is_prediction === 1 && !visiblePredictionIndexes.has(zi)) {
+                continue;
+            }
             if (dayX >= z.startX && dayX <= z.endX) {
                 const prev = bmd.zones[zi - 1] || null;
                 const cycleLow = bmd.cycleData[bmd.cycleLowIdx]?.low ?? null;

--- a/03_frontend/public/legacy/dist/chart-render-overlays.js
+++ b/03_frontend/public/legacy/dist/chart-render-overlays.js
@@ -1,6 +1,6 @@
 // Overlay elements: box marks, bear/bull labels, cycle low & prediction markers
 import { chartState } from './chart-logic.js';
-import { getBtcAnchorInfo, getPhaseBoxStatsForSymbol, dayToTime, timeToDay, getScenarioKey, SCENARIO_STYLE } from './chart-logic.js';
+import { getBtcAnchorInfo, getPhaseBoxStatsForSymbol, dayToTime, timeToDay, getScenarioKey, SCENARIO_STYLE, getVisiblePredictionZoneIndexes, getVisiblePredictionDayRanges } from './chart-logic.js';
 function normalizedRateToUsd(rate, cycleRef) {
     const basePrice = Number(cycleRef?.peak_price);
     const normalizedRate = Number(rate);
@@ -160,14 +160,58 @@ export function renderBoxMarks(zones, cycleLowIdx, cycleData, timeScale, series,
         }
         placed.push(getLabelRectInOverlay(el));
     }
+    function addForecastGuide(day, label, kind) {
+        const dayNum = Number(day);
+        if (!Number.isFinite(dayNum)) {
+            return;
+        }
+        let x = timeScale.timeToCoordinate(dayToTime(dayNum));
+        if (x === null) {
+            x = clampCoordToVisible(timeScale, dayNum, overlayWidth);
+        }
+        const guide = document.createElement('div');
+        guide.className = `forecast-guide ${kind}`;
+        guide.style.left = x + 'px';
+        guide.style.height = chartHeight + 'px';
+        overlay.appendChild(guide);
+        chartState.boxMarkEls.push(guide);
+        const guideLabel = document.createElement('div');
+        guideLabel.className = `forecast-guide-label ${kind}`;
+        guideLabel.textContent = label;
+        guideLabel.style.left = Math.max(44, Math.min(overlayWidth - 44, x)) + 'px';
+        guideLabel.style.top = '8px';
+        overlay.appendChild(guideLabel);
+        chartState.boxMarkEls.push(guideLabel);
+    }
     const btcAnchor = getBtcAnchorInfo(cycleNumber);
     const phaseBoxStats = getPhaseBoxStatsForSymbol(coinSymbol, 'BULL'); // BULL/Bear 모두 참고
     const isBtcChart = (coinSymbol || '').toUpperCase() === 'BTC';
+    const predictionScopeZones = zones.length > 0 ? zones : cycleRef?.box_zones || [];
+    const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(predictionScopeZones, cycleData);
+    const visiblePredictionDayRanges = getVisiblePredictionDayRanges(predictionScopeZones, cycleData);
+    const isVisiblePredictionDay = (day) => {
+        const dayNum = Number(day);
+        if (!Number.isFinite(dayNum)) {
+            return false;
+        }
+        if (visiblePredictionDayRanges === null) {
+            return chartState.showPrediction;
+        }
+        return visiblePredictionDayRanges.some((range) => dayNum >= range.startX && dayNum <= range.endX);
+    };
+    const firstVisiblePrediction = Array.from(visiblePredictionIndexes)
+        .map((idx) => predictionScopeZones[idx])
+        .filter(Boolean)
+        .sort((a, b) => Number(a.startX) - Number(b.startX) || Number(a.endX) - Number(b.endX))[0];
+    if (chartState.showPrediction && visiblePredictionIndexes.size > 0) {
+        addForecastGuide(cycleData[cycleData.length - 1]?.x, 'NOW', 'now');
+        addForecastGuide(firstVisiblePrediction?.startX, 'FORECAST', 'forecast');
+    }
     if (chartState.showBoxZone && zones.length > 0) {
         zones.forEach((z, zi) => {
             const isBear = z.phase === 'BEAR';
             const isPrediction = z.is_prediction === 1; // 예측 박스 플래그
-            if (isPrediction && !chartState.showPrediction) {
+            if (isPrediction && !visiblePredictionIndexes.has(zi)) {
                 return;
             }
             const result = String(z.result || '').toUpperCase();
@@ -688,6 +732,8 @@ export function renderBoxMarks(zones, cycleLowIdx, cycleData, timeScale, series,
     if (chartState.showPrediction && cycleRef && cycleRef.peak_predictions && cycleRef.peak_predictions.length > 0) {
         cycleRef.peak_predictions.forEach((p) => {
             const dayX = p.day_x;
+            if (!isVisiblePredictionDay(dayX))
+                return;
             if (p.value == null || !Number.isFinite(p.value))
                 return;
             let val = p.value;
@@ -742,11 +788,11 @@ export function renderBoxMarks(zones, cycleLowIdx, cycleData, timeScale, series,
     }
     // prediction path end labels
     if (chartState.showPrediction && cycleRef && cycleRef.prediction_paths) {
-        const bullPts = cycleRef.prediction_paths.bull;
-        const bearPts = cycleRef.prediction_paths.bear;
+        const bullPts = cycleRef.prediction_paths.bull || [];
+        const bearPts = cycleRef.prediction_paths.bear || [];
         if (bullPts && bullPts.length > 1) {
             const lastU = bullPts[bullPts.length - 1];
-            if (lastU && lastU.value != null && Number.isFinite(lastU.value)) {
+            if (lastU && lastU.value != null && Number.isFinite(lastU.value) && isVisiblePredictionDay(lastU.x)) {
                 const xU = timeScale.timeToCoordinate(dayToTime(lastU.x));
                 if (xU == null)
                     return;
@@ -765,7 +811,7 @@ export function renderBoxMarks(zones, cycleLowIdx, cycleData, timeScale, series,
         }
         if (bearPts && bearPts.length > 1) {
             const lastB = bearPts[bearPts.length - 1];
-            if (lastB && lastB.value != null && Number.isFinite(lastB.value)) {
+            if (lastB && lastB.value != null && Number.isFinite(lastB.value) && isVisiblePredictionDay(lastB.x)) {
                 const xEnd = timeScale.timeToCoordinate(dayToTime(lastB.x));
                 if (xEnd == null)
                     return;

--- a/03_frontend/public/legacy/dist/chart-series-boxzone.js
+++ b/03_frontend/public/legacy/dist/chart-series-boxzone.js
@@ -1,6 +1,6 @@
 // ── Box zone series (hi/lo lines, fill area, active extension) ─────────────
 import { chartState } from './chart-logic.js';
-import { dayToTime, detectBoxZones } from './chart-logic.js';
+import { dayToTime, detectBoxZones, getVisiblePredictionZoneIndexes } from './chart-logic.js';
 import { setSeriesDataSafe, filterValidPoints } from './chart-series-helpers.js';
 import { renderBoxMarks } from './chart-render-overlays.js';
 // z.hi / z.lo / z.startX / z.endX 가 하나라도 NaN/null 이면 skip
@@ -20,7 +20,7 @@ function safePrice(val, fallback = 0) {
 function getBoxZoneColors(isPred, isBearBox) {
     if (isPred) {
         const rgb = isBearBox ? '255,107,107' : '255,217,102';
-        return { lineColor: `rgba(${rgb},0.80)`, fillTop: `rgba(${rgb},0.10)`, fillBot: `rgba(${rgb},0.01)` };
+        return { lineColor: `rgba(${rgb},0.38)`, fillTop: `rgba(${rgb},0.075)`, fillBot: `rgba(${rgb},0.01)` };
     }
     const rgb = isBearBox ? '255,68,102' : '255,184,0';
     return { lineColor: `rgba(${rgb},0.85)`, fillTop: `rgba(${rgb},0.14)`, fillBot: `rgba(${rgb},0.04)` };
@@ -86,10 +86,11 @@ export function addBoxZoneSeries(coinId, coinData, cycle, cycleNum, cycleMinLowI
     }
     const hasDbZones = cycle.box_zones && cycle.box_zones.length > 0;
     const rawZones = hasDbZones ? cycle.box_zones : detectBoxZones(cycle.data);
-    const zones = chartState.showPrediction
-        ? rawZones
-        : rawZones.filter((z) => z.is_prediction !== 1);
-    zones.forEach((z, zi) => {
+    const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(rawZones, cycle.data);
+    const zones = rawZones;
+    rawZones.forEach((z, zi) => {
+        if (z.is_prediction === 1 && !visiblePredictionIndexes.has(zi))
+            return;
         if (!isValidZone(z))
             return;
         const { lineColor, fillTop, fillBot } = getBoxZoneColors(z.is_prediction === 1, z.phase === 'BEAR');
@@ -126,8 +127,9 @@ export function addActiveBoxExtensions(coinId, coinData, cycle, cycleNum) {
         return;
     const lastRealDay = cycle.data[cycle.data.length - 1]?.x ?? 0;
     const lastRealClose = cycle.data[cycle.data.length - 1]?.close ?? 100;
-    cycle.box_zones.forEach((z) => {
-        if (!chartState.showPrediction && z.is_prediction === 1)
+    const visiblePredictionIndexes = getVisiblePredictionZoneIndexes(cycle.box_zones, cycle.data);
+    cycle.box_zones.forEach((z, zi) => {
+        if (z.is_prediction === 1 && !visiblePredictionIndexes.has(zi))
             return;
         const result = String(z.result || '').toUpperCase();
         const isAct = result === 'BEAR_ACTIVE' || result === 'BULL_ACTIVE' ||

--- a/03_frontend/public/legacy/dist/chart-series-prediction.js
+++ b/03_frontend/public/legacy/dist/chart-series-prediction.js
@@ -1,6 +1,6 @@
 // ── Prediction path series (bull / bear dotted lines) ──────────────────────
 import { chartState } from './chart-logic.js';
-import { dayToTime, buildStepSeries, sanitizePathPoints } from './chart-logic.js';
+import { dayToTime, buildStepSeries, sanitizePathPoints, getVisiblePredictionDayRanges } from './chart-logic.js';
 import { setSeriesDataSafe, filterValidPoints } from './chart-series-helpers.js';
 function buildPathLinePoints(rawPts) {
     return rawPts
@@ -18,7 +18,7 @@ function addSinglePathSeries(pts, color, kind, seriesKey, meta) {
     const seriesData = buildStepSeries(linePoints);
     const pathSeries = chartState.chart.addLineSeries({
         color,
-        lineWidth: 2,
+        lineWidth: 1,
         lineStyle: LightweightCharts.LineStyle.Dotted,
         priceLineVisible: false,
         lastValueVisible: false,
@@ -34,11 +34,21 @@ export function addPredictionPaths(coinId, coinData, cycle, cycleNum) {
         return;
     let bullPts = sanitizePathPoints(cycle.prediction_paths.bull || []);
     let bearPts = sanitizePathPoints(cycle.prediction_paths.bear || []);
+    const visibleRanges = getVisiblePredictionDayRanges(cycle.box_zones || [], cycle.data || []);
+    if (visibleRanges !== null) {
+        const isVisibleDay = (day) => {
+            const dayNum = Number(day);
+            return Number.isFinite(dayNum) &&
+                visibleRanges.some((range) => dayNum >= range.startX && dayNum <= range.endX);
+        };
+        bullPts = bullPts.filter((p) => isVisibleDay(p.x));
+        bearPts = bearPts.filter((p) => isVisibleDay(p.x));
+    }
     const meta = { coinId, symbol: coinData.symbol, cycleName: cycle.cycle_name, cycleNum };
     if (bullPts && bullPts.length > 1) {
-        addSinglePathSeries(bullPts, 'rgba(255,217,102,0.85)', 'pred_bull', `${coinId}_${cycle.cycle_number}_path_bull`, meta);
+        addSinglePathSeries(bullPts, 'rgba(255,217,102,0.36)', 'pred_bull', `${coinId}_${cycle.cycle_number}_path_bull`, meta);
     }
     if (bearPts && bearPts.length > 1) {
-        addSinglePathSeries(bearPts, 'rgba(255,107,107,0.85)', 'pred_bear', `${coinId}_${cycle.cycle_number}_path_bear`, meta);
+        addSinglePathSeries(bearPts, 'rgba(255,107,107,0.36)', 'pred_bear', `${coinId}_${cycle.cycle_number}_path_bear`, meta);
     }
 }

--- a/03_frontend/public/legacy/dist/chart-ui.js
+++ b/03_frontend/public/legacy/dist/chart-ui.js
@@ -181,12 +181,35 @@ function toggleBoxZone() {
 }
 function toggleBearBull() {
     chartState.showPrediction = !chartState.showPrediction;
+    if (!chartState.showPrediction) {
+        chartState.showExtendedForecast = false;
+    }
     const btn = document.getElementById('toggleBearBull');
     if (btn) {
         btn.style.cssText = chartState.showPrediction
             ? 'border-color:#ff6bb5;color:#ff6bb5;background:rgba(255,107,181,0.1)'
             : 'border-color:#4a6080;color:#4a6080;';
     }
+    updateExtendedForecastButton();
+    drawChart();
+}
+function updateExtendedForecastButton() {
+    const btn = document.getElementById('toggleExtendedForecast');
+    if (!btn)
+        return;
+    btn.disabled = !chartState.showPrediction;
+    btn.style.cssText =
+        chartState.showPrediction && chartState.showExtendedForecast
+            ? 'border-color:#a78bfa;color:#d8ccff;background:rgba(167,139,250,0.12)'
+            : chartState.showPrediction
+                ? 'border-color:#4a6080;color:#4a6080;'
+                : 'border-color:#26364f;color:#344966;opacity:0.55;';
+}
+function toggleExtendedForecast() {
+    if (!chartState.showPrediction)
+        return;
+    chartState.showExtendedForecast = !chartState.showExtendedForecast;
+    updateExtendedForecastButton();
     drawChart();
 }
 // ── Defaults & Bottom Override UI ─────────────────────
@@ -224,6 +247,7 @@ export function initDefaults() {
             ? 'border-color:#ff6bb5;color:#ff6bb5;background:rgba(255,107,181,0.1)'
             : 'border-color:#4a6080;color:#4a6080;';
     }
+    updateExtendedForecastButton();
 }
 // ── Wire DOM events & expose toggles for onclick ───────
 const searchInput = document.getElementById('searchInput');
@@ -236,3 +260,4 @@ if (searchInput) {
 window.toggleHighLow = toggleHighLow;
 window.toggleBoxZone = toggleBoxZone;
 window.toggleBearBull = toggleBearBull;
+window.toggleExtendedForecast = toggleExtendedForecast;

--- a/reports/83.md
+++ b/reports/83.md
@@ -1,0 +1,27 @@
+## What Was Found
+- The legacy analyzer needed a way to hide distant forecast boxes by default while still allowing them to be inspected on demand.
+- Previous prediction overlays could become visually inconsistent when prediction paths, labels, and box zones were filtered differently.
+
+## What Changed
+- Added an `EXTENDED` toggle to the legacy analyzer controls.
+- Default forecast view now shows only the active/current prediction zone plus the next prediction zone.
+- `EXTENDED` mode shows all future prediction zones and paths.
+- Prediction paths, prediction labels, peak/bottom markers, tooltips, and box zones now share the same visible prediction scope.
+- `PREDICT OFF` disables the extended state and hides forecast overlays together.
+- Synced the generated legacy assets used by `03_frontend`.
+
+## Review Notes
+- Team review found two consistency risks:
+  - clipped prediction path end labels could look like final forecast labels;
+  - missing prediction box zones could cause EXTENDED OFF to show a full prediction path.
+- Both cases were corrected before commit.
+
+## Tests
+- `01_pairUSDT`: `npm run check:ts` passed.
+- `01_pairUSDT`: `npm run build:ts` passed.
+- `03_frontend`: `npm run build` passed.
+- `git diff --check` passed.
+
+## PR
+- Issue: #83
+- PR: to be created


### PR DESCRIPTION
## Summary
- Add EXTENDED toggle for distant forecast display in the legacy analyzer.
- Keep default prediction view scoped to the active/current forecast plus the next forecast zone.
- Keep prediction paths, labels, markers, tooltips, and box zones aligned across PREDICT/EXTENDED states.
- Sync generated legacy assets for 03_frontend.

## Tests
- npm run check:ts (01_pairUSDT)
- npm run build:ts (01_pairUSDT)
- npm run build (03_frontend)
- git diff --check

Closes #83